### PR TITLE
Update MAETealDataset.R

### DIFF
--- a/R/MAETealDataset.R
+++ b/R/MAETealDataset.R
@@ -197,7 +197,7 @@ MAETealDataset <- R6::R6Class( # nolint
   ),
   ## __Private Fields ====
   private = list(
-    .raw_data = MultiAssayExperiment::MultiAssayExperiment(),
+    .raw_data = NULL,
     get_class_colnames = function(class_type = "character") {
       checkmate::assert_string(class_type)
 


### PR DESCRIPTION
closes #22 

The default of `.raw_data` slot could be NULL as we have stopifnot for the provided object. It has to have a MAE class and exists.

Normally the function body is delayed evaluated. This is not the case for some of R6Class object slots which is called directly like here https://github.com/insightsengineering/teal.data/blob/2d3e5db000123e4908df0be2d0d90e84980377c0/R/MAETealDataset.R#L200. We could solve it easily e.g. with a  function() x call. It takes a lot of time to debug;o. This is not a problem on our CI (github actions), as only check with --as-cran option is failing. The --as-cran option make the check more strict and packages outside DESCRIPTION file could NOT be used.
