### PR TITLE
update readme

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,9 +45,9 @@ Suggests:
     SummarizedExperiment,
     testthat (>= 2.0)
 Remotes:
-    insightsengineering/teal.logger@*release,
-    insightsengineering/scda@*release,
-    insightsengineering/scda.2021@*release
+    github::insightsengineering/teal.logger@*release,
+    github::insightsengineering/scda@*release,
+    github::insightsengineering/scda.2021@*release
 VignetteBuilder:
     knitr
 RdMacros:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,9 +45,9 @@ Suggests:
     SummarizedExperiment,
     testthat (>= 2.0)
 Remotes:
-    github::insightsengineering/teal.logger@*release,
-    github::insightsengineering/scda@*release,
-    github::insightsengineering/scda.2021@*release
+    insightsengineering/teal.logger@*release,
+    insightsengineering/scda@*release,
+    insightsengineering/scda.2021@*release
 VignetteBuilder:
     knitr
 RdMacros:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,6 +44,10 @@ Suggests:
     scda.2021 (>= 0.1.3),
     SummarizedExperiment,
     testthat (>= 2.0)
+Remotes:
+    insightsengineering/teal.logger@*release,
+    insightsengineering/scda@*release,
+    insightsengineering/scda.2021@*release
 VignetteBuilder:
     knitr
 RdMacros:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,10 @@ It is recommended that you [create and use a Github PAT](https://docs.github.com
 
 ```r
 Sys.setenv(GITHUB_PAT = "your_access_token_here")
-if (!require("devtools")) install.packages("devtools")
-devtools::install_github("insightsengineering/teal.data@*release", dependencies = FALSE)
+if (!require("remotes")) install.packages("remotes")
+remotes::install_github("insightsengineering/teal.data@*release")
 ```
 
-You might need to manually install all of the package dependencies before installing this package as without
-the `dependencies = FALSE` argument to `install_github` it may produce an error.
+A stable release of all `NEST` packages is also available [here](https://github.com/insightsengineering/depository#readme).
 
 See package vignettes `browseVignettes(package = "teal.data")` for usage of this package.


### PR DESCRIPTION
Part of https://github.com/insightsengineering/teal/issues/668

Test with `remotes::install_github("insightsengineering/teal.data@668_instll_td@main")` once https://github.com/insightsengineering/idr-tasks/issues/343 has been completed though note of course that it will install the released version of teal.logger

As we are only using this to install released packages (and staged.deps for when we as devs are developing) this should be all we need)
