### PR TITLE
vbump testthat

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     reticulate (>= 1.22),
     rmarkdown (>= 2.19),
     SummarizedExperiment,
-    testthat (>= 3.0.4),
+    testthat (>= 3.1.5),
     withr (>= 2.1.0)
 VignetteBuilder:
     knitr


### PR DESCRIPTION
Fix failing min verdepcheck test:
```
* checking tests ...
  Running ‘testthat.R’
 ERROR
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
  ══ Failed tests ════════════════════════════════════════════════════════════════
  ── Error (test-datanames.R:23:3): only names of existing variables are accepted ──
  Error: 'expect_no_error' is not an exported object from 'namespace:testthat'
  ── Error (test-datanames.R:30:3): datanames supports qenv.error class ──────────
  Error: 'expect_no_error' is not an exported object from 'namespace:testthat'
  ── Error (test-teal_data.R:88:3): teal_data accepts any data provided as named list ──
  Error: 'expect_no_error' is not an exported object from 'namespace:testthat'
  ── Error (test-teal_data.R:92:3): teal_data accepts code as character ──────────
  Error: 'expect_no_error' is not an exported object from 'namespace:testthat'
  ── Error (test-teal_data.R:101:3): teal_data accepts code as language ──────────
  Error: 'expect_no_error' is not an exported object from 'namespace:testthat'
  
  [ FAIL 5 | WARN 0 | SKIP 1 | PASS 1132 ]
  Error: Test failures
  Execution halted
```
