### PR TITLE
update repo roster link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ If you encounter a bug or you have a feature request - please file an issue. For
 
 ### Stargazers
 
-[![Stargazers repo roster for @insightsengineering/teal.data](https://reporoster.com/stars/insightsengineering/teal.data)](https://github.com/insightsengineering/teal.data/stargazers)
+[![Stargazers repo roster for @insightsengineering/teal.data](http://reporoster.com/stars/insightsengineering/teal.data)](https://github.com/insightsengineering/teal.data/stargazers)
 
 ### Forkers
 
-[![Forkers repo roster for @insightsengineering/teal.data](https://reporoster.com/forks/insightsengineering/teal.data)](https://github.com/insightsengineering/teal.data/network/members)
+[![Forkers repo roster for @insightsengineering/teal.data](http://reporoster.com/forks/insightsengineering/teal.data)](https://github.com/insightsengineering/teal.data/network/members)


### PR DESCRIPTION
Related with https://github.com/insightsengineering/teal/issues/949, updating the link to `reporoster` in README.