### PR TITLE
`get_code` to return concatenated code string and removed `format_expression`

### DIFF
--- a/R/teal_data-class.R
+++ b/R/teal_data-class.R
@@ -71,7 +71,7 @@ new_teal_data <- function(data,
   }
 
   if (is.language(code)) {
-    code <- format_expression(code)
+    code <- paste(lang2calls(code), collapse = "\n")
   }
   if (length(code)) {
     code <- paste(code, collapse = "\n")

--- a/R/teal_data-get_code.R
+++ b/R/teal_data-get_code.R
@@ -11,7 +11,7 @@
 #' @param deparse (`logical`) flag specifying whether to return code as `character` (`deparse = TRUE`) or as
 #' `expression` (`deparse = FALSE`).
 #' @return
-#' Either string or expression representing code used to create the requested data sets.
+#' Either string or an expression representing code used to create the requested data sets.
 #' @examples
 #'
 #' tdata1 <- teal_data()

--- a/R/teal_data-get_code.R
+++ b/R/teal_data-get_code.R
@@ -11,7 +11,7 @@
 #' @param deparse (`logical`) flag specifying whether to return code as `character` (`deparse = TRUE`) or as
 #' `expression` (`deparse = FALSE`).
 #' @return
-#' Either a character vector or expression representing code used to create the requested data sets.
+#' Either string or expression representing code used to create the requested data sets.
 #' @examples
 #'
 #' tdata1 <- teal_data()
@@ -46,7 +46,11 @@ setMethod("get_code", "teal_data", definition = function(object, deparse = TRUE,
   }
 
   if (deparse) {
-    code
+    if (length(code) == 0) {
+      code
+    } else {
+      paste(code, collapse = "\n")
+    }
   } else {
     parse(text = code, keep.source = TRUE)
   }

--- a/R/teal_data-get_code.R
+++ b/R/teal_data-get_code.R
@@ -52,6 +52,6 @@ setMethod("get_code", "teal_data", definition = function(object, deparse = TRUE,
       paste(code, collapse = "\n")
     }
   } else {
-    parse(text = code, keep.source = TRUE)
+    parse(text = paste(c("{", code, "}"), collapse = "\n"), keep.source = TRUE)
   }
 })

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,4 +17,4 @@
 }
 
 # use non-exported function from teal.code
-format_expression <- getFromNamespace("format_expression", "teal.code")
+lang2calls <- getFromNamespace("lang2calls", "teal.code")

--- a/man/get_code-teal_data-method.Rd
+++ b/man/get_code-teal_data-method.Rd
@@ -15,7 +15,7 @@
 \item{datanames}{(\code{character}) vector of data set names to return the code for.}
 }
 \value{
-Either a character vector or expression representing code used to create the requested data sets.
+Either string or expression representing code used to create the requested data sets.
 }
 \description{
 Retrieve code from \code{teal_data} object.

--- a/man/get_code-teal_data-method.Rd
+++ b/man/get_code-teal_data-method.Rd
@@ -15,7 +15,7 @@
 \item{datanames}{(\code{character}) vector of data set names to return the code for.}
 }
 \value{
-Either string or expression representing code used to create the requested data sets.
+Either string or an expression representing code used to create the requested data sets.
 }
 \description{
 Retrieve code from \code{teal_data} object.


### PR DESCRIPTION
part of https://github.com/insightsengineering/teal.code/pull/176
