### PR TITLE
bug fix: `teal_data` appears empty when app starts 

### DIFF
--- a/R/teal_data.R
+++ b/R/teal_data.R
@@ -49,6 +49,15 @@ teal_data <- function(...,
     if (length(data_objects) > 0 && !checkmate::test_names(names(data_objects), type = "named")) {
       stop("Dot (`...`) arguments on `teal_data()` must be named.")
     }
+
+    if(length(data_objects) > 0 && length(code) == 0) {
+      arg_list <- match.call(expand.dots = FALSE)$`...`
+      code_string <- sapply(names(data_objects), function(name) {
+        argument_string <- arg_list[[name]]
+        paste0(name, " <- ", argument_string)
+      }, USE.NAMES = FALSE)
+      code <- paste(code_string, collapse = "\n")
+    }
     new_teal_data(
       data = data_objects,
       code = code,

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -3,7 +3,7 @@ warning_message <- "warning('Code was not verified for reproducibility.')"
 testthat::test_that("get_code with datanames handles empty @code slot", {
   testthat::expect_identical(
     get_code(teal_data(a = 1, code = character(0)), datanames = "a"),
-    warning_message
+    paste(warning_message, "a <- 1", sep  = "\n")
   )
   testthat::expect_identical(
     get_code(teal_data(a = 1, code = ""), datanames = "a"),


### PR DESCRIPTION
this is fixes: https://github.com/insightsengineering/teal/issues/985

**Problem Description:**
When launching the app or initially loading a module, `get_code_dependency `  triggers console warnings. This issue is  the warning message:
```
Warning in teal.data:::get_code_dependency(attr(datasets, "preprocessing_code"),  :
  Objects not found in 'qenv' environment: IRIS, NPK

```
The problem occurs during the execution of the following code:
```
app <- init(
  data = teal_data(IRIS = iris, NPK = npk),
  modules = modules(
    example_module(label = "example 1"),
    example_module(label = "example 2")
  )
)

runApp(app)
```
This issue arises in the `teal_data_to_filtered_data` function, which extracts code to piggyback the entire preprocessing sequence. However, if `teal_data` is initialized without embedded code, it lacks the preprocessing code. This can be observed in the screenshot below:
<img width="678" alt="image" src="https://github.com/insightsengineering/teal.data/assets/6700955/61cb9f61-005e-4b1e-a6e7-aed13839de39">

**Resolution:**
Initializing teal_data with code resolves this issue, as shown below:
```
data <- teal_data(IRIS = iris,
                  MTCARS =mtcars,code = "IRIS = iris\nMTCARS =mtcars")
```

**Proposed Solution:**
I modified the `teal_data `constructor to automatically extract the '...' (ellipsis) argument and convert it into a code string, which is then set in the code slot. This approach resolves the issue. However, I am not able to find solution to directly in `teal`, as the ellipsis argument cannot be accessed there and is only valid in the constructor.

This fix seems to resolve the issue without introducing new problems. Let me know your thoughts and feedback on this solution.