### PR TITLE
985 parametrize name check in get_code_dependency

### DIFF
--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -19,12 +19,13 @@
 #'
 #' @param code `character` with the code.
 #' @param names `character` vector of object names.
+#' @param check_names `logical(1)` flag specifying if a warning for non-existing names should be displayed.
 #'
 #' @return Character vector, a subset of `code`.
 #' Note that subsetting is actually done on the calls `code`, not necessarily on the elements of the vector.
 #'
 #' @keywords internal
-get_code_dependency <- function(code, names) {
+get_code_dependency <- function(code, names, check_names = TRUE) {
   checkmate::assert_character(code)
   checkmate::assert_character(names, any.missing = FALSE)
 
@@ -35,10 +36,12 @@ get_code_dependency <- function(code, names) {
   code <- parse(text = code, keep.source = TRUE)
   pd <- utils::getParseData(code)
 
-  # Detect if names are actually in code.
-  symbols <- unique(pd[pd$token == "SYMBOL", "text"])
-  if (!all(names %in% symbols)) {
-    warning("Object(s) not found in code: ", toString(setdiff(names, symbols)))
+  if (check_names) {
+    # Detect if names are actually in code.
+    symbols <- unique(pd[pd$token == "SYMBOL", "text"])
+    if (!all(names %in% symbols)) {
+      warning("Object(s) not found in code: ", toString(setdiff(names, symbols)))
+    }
   }
 
   calls_pd <- extract_calls(pd)

--- a/man/get_code_dependency.Rd
+++ b/man/get_code_dependency.Rd
@@ -4,12 +4,14 @@
 \alias{get_code_dependency}
 \title{Get Code Dependency of an Object}
 \usage{
-get_code_dependency(code, names)
+get_code_dependency(code, names, check_names = TRUE)
 }
 \arguments{
 \item{code}{\code{character} with the code.}
 
 \item{names}{\code{character} vector of object names.}
+
+\item{check_names}{\code{logical(1)} flag specifying if a warning for non-existing names should be displayed.}
 }
 \value{
 Character vector, a subset of \code{code}.


### PR DESCRIPTION
Alternative for https://github.com/insightsengineering/teal.data/pull/219 potentially fixes https://github.com/insightsengineering/teal/issues/985 if we extend `get_code_dependency` usage with `check_names = FALSE` in teal - provided in https://github.com/insightsengineering/teal/pull/1012