### PR TITLE
224 collapse expression `get_code(deparse=FALSE)`

### DIFF
--- a/R/teal_data-get_code.R
+++ b/R/teal_data-get_code.R
@@ -57,6 +57,6 @@ setMethod("get_code", signature = "teal_data", definition = function(object, dep
       paste(code, collapse = "\n")
     }
   } else {
-    parse(text = code, keep.source = TRUE)
+    parse(text = paste(c("{", code, "}"), collapse = "\n"), keep.source = TRUE)
   }
 })

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -209,6 +209,20 @@ testthat::test_that("get_code with datanames detects every assign calls even if 
   )
 })
 
+testthat::test_that("get_code returns result of length for non-empty input",{
+
+  tdata1 <- teal_data()
+  tdata1 <- within(tdata1, {
+    a <- 1
+    b <- a^5
+    c <- list(x = 2)
+  })
+
+  testthat::expect_length(get_code(tdata1, deparse = FALSE), 1)
+  testthat::expect_length(get_code(tdata1, deparse = TRUE), 1)
+
+})
+
 
 # @linksto ---------------------------------------------------------------------------------------------------------
 

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -209,8 +209,7 @@ testthat::test_that("get_code with datanames detects every assign calls even if 
   )
 })
 
-testthat::test_that("get_code returns result of length for non-empty input",{
-
+testthat::test_that("get_code returns result of length for non-empty input", {
   tdata1 <- teal_data()
   tdata1 <- within(tdata1, {
     a <- 1
@@ -220,7 +219,6 @@ testthat::test_that("get_code returns result of length for non-empty input",{
 
   testthat::expect_length(get_code(tdata1, deparse = FALSE), 1)
   testthat::expect_length(get_code(tdata1, deparse = TRUE), 1)
-
 })
 
 


### PR DESCRIPTION
Close #224

Before

```r
library(teal.data)
tdata1 <- teal_data()
tdata1 <- within(tdata1, {
  a <- 1
  b <- a^5
  c <- list(x = 2)
})

length(get_code(tdata1, deparse = FALSE))
# > [1] 3
length(get_code(tdata1, deparse = TRUE))
# > [1] 1


get_code(tdata1, deparse = FALSE)
# > expression(a <- 1, b <- a^5, c <- list(x = 2))

```

After

```r
library(teal.data)
tdata1 <- teal_data()
tdata1 <- within(tdata1, {
  a <- 1
  b <- a^5
  c <- list(x = 2)
})

length(get_code(tdata1, deparse = FALSE))
# > [1] 1
length(get_code(tdata1, deparse = TRUE))
# > [1] 1

get_code(tdata1, deparse = FALSE)
# > expression({
# > a <- 1
# > b <- a^5
# > c <- list(x = 2)
# > })
```