### PR TITLE
improve label functions

### DIFF
--- a/R/formatters_var_labels.R
+++ b/R/formatters_var_labels.R
@@ -5,7 +5,7 @@
 #' Variable labels can be stored as a `label` attribute set on individual variables.
 #' These functions get or set this attribute, either on all (`col_labels`) or some variables (`col_relabel`).
 #'
-#' @param x `data.frame`
+#' @param x (`data.frame` or `DataFrame`) data object
 #' @param fill (`logical(1)`) specifying what to return if variable has no label
 #' @param value (`character`) vector of variable labels of length equal to number of columns in `x`;
 #'  if named, names must match variable names in `x` and will be used as key to set labels;
@@ -35,7 +35,7 @@
 #' @export
 #'
 col_labels <- function(x, fill = FALSE) {
-  checkmate::assert_data_frame(x)
+  checkmate::test_multi_class(x, c("data.frame", "DataFrame"))
   checkmate::assert_flag(fill)
 
   if (ncol(x) == 0L) {
@@ -65,7 +65,7 @@ col_labels <- function(x, fill = FALSE) {
 #' @rdname col_labels
 #' @export
 `col_labels<-` <- function(x, value) {
-  checkmate::assert_data_frame(x)
+  checkmate::test_multi_class(x, c("data.frame", "DataFrame"))
   checkmate::assert_character(value)
   checkmate::assert_true(
     ncol(x) == length(value),
@@ -83,7 +83,7 @@ col_labels <- function(x, fill = FALSE) {
 #' @export
 #'
 col_relabel <- function(x, ...) {
-  checkmate::assert_data_frame(x)
+  checkmate::test_multi_class(DF, c("data.frame", "DataFrame"))
   if (missing(...)) {
     return(x)
   }

--- a/man/col_labels.Rd
+++ b/man/col_labels.Rd
@@ -18,7 +18,7 @@ col_labels(x) <- value
 col_relabel(x, ...)
 }
 \arguments{
-\item{x}{\code{data.frame}}
+\item{x}{(\code{data.frame} or \code{DataFrame}) data object}
 
 \item{fill}{(\code{logical(1)}) specifying what to return if variable has no label}
 

--- a/man/col_labels.Rd
+++ b/man/col_labels.Rd
@@ -6,9 +6,9 @@
 \alias{col_relabel}
 \title{Variable Labels}
 \source{
-This function was taken 1-1 from
+These functions were taken from
 \href{https://cran.r-project.org/package=formatters}{formatters} package, to reduce the complexity of
-the dependency tree.
+the dependency tree and rewritten.
 }
 \usage{
 col_labels(x, fill = FALSE)


### PR DESCRIPTION
Rewrote `col_labels`, `col_;labels<-` and `col_relabel`.
All existing unit tests pass.

This is only a suggestion, the functions do their job properly. They have been copied from `formatters`, which is an argument _against_ these changes.