### PR TITLE
refining tags in documentation

### DIFF
--- a/R/cdisc_data.R
+++ b/R/cdisc_data.R
@@ -1,6 +1,8 @@
 #' Data input for `teal` app
 #'
-#' `r lifecycle::badge("stable")`\cr
+#' @description
+#' `r lifecycle::badge("stable")`
+#'
 #' Function is a wrapper around [teal_data()] and guesses `join_keys`
 #' for given datasets whose names match ADAM datasets names.
 #'

--- a/R/cdisc_data.R
+++ b/R/cdisc_data.R
@@ -1,6 +1,6 @@
 #' Data input for `teal` app
 #'
-#' @description `r lifecycle::badge("stable")`
+#' `r lifecycle::badge("stable")`\cr
 #' Function is a wrapper around [teal_data()] and guesses `join_keys`
 #' for given datasets whose names match ADAM datasets names.
 #'
@@ -12,9 +12,7 @@
 #'
 #' @return A `teal_data` object.
 #'
-#' @details This function checks if there were keys added to all data sets
-#'
-#' @export
+#' @details This function checks if there were keys added to all data sets.
 #'
 #' @examples
 #' data <- cdisc_data(
@@ -27,6 +25,8 @@
 #'   ADSL <- example_cdisc_data("ADSL")
 #'   ADTTE <- example_cdisc_data("ADTTE")
 #' })
+#'
+#' @export
 #'
 cdisc_data <- function(...,
                        join_keys = teal.data::default_cdisc_join_keys[names(rlang::list2(...))],

--- a/R/cdisc_data.R
+++ b/R/cdisc_data.R
@@ -7,7 +7,8 @@
 #' for given datasets whose names match ADAM datasets names.
 #'
 #' @inheritParams teal_data
-#' @param join_keys (`join_keys`) object or a single (`join_key_set`) object\cr
+#' @param join_keys (`join_keys`) object or a single (`join_key_set`) object
+#'
 #'   (optional) object with datasets column names used for joining.
 #'   If empty then it would be automatically derived basing on intersection of datasets primary keys.
 #'   For ADAM datasets it would be automatically derived.

--- a/R/data.R
+++ b/R/data.R
@@ -1,116 +1,82 @@
 #' Random adverse events
 #'
-#' @description Random adverse events.
 #' @docType data
-#'
 #' @usage rADAE
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADAE
 "rADAE"
 
 #' Random concomitant medications
 #'
-#' @description Random concomitant medications.
 #' @docType data
-#'
 #' @usage rADCM
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADCM
 "rADCM"
 
 #' Random response
 #'
-#' @description Random exposure.
+#' Random exposure.
+#'
 #' @docType data
-#'
 #' @usage rADEX
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADEX
 "rADEX"
 
 #' Random lab analysis
 #'
-#' @description Random lab analysis.
 #' @docType data
-#'
 #' @usage rADLB
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADLB
 "rADLB"
 
 #' Random response
 #'
-#' @description Random response.
 #' @docType data
-#'
 #' @usage rADRS
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADRS
 "rADRS"
 
 #' Random patient listing
 #'
-#' @description Random patient listing.
 #' @docType data
-#'
 #' @usage rADSL
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADSL
 "rADSL"
 
 #' Random data `rADTR`
 #'
-#' @description Random data `rADTR`.
 #' @docType data
-#'
 #' @usage rADTR
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADTR
 "rADTR"
 
 #' Random time to event analysis dataset
 #'
-#' @description Random time to event analysis dataset.
 #' @docType data
-#'
 #' @usage rADTTE
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADTTE
 "rADTTE"
 
 #' Random data `rADVS`
 #'
-#' @description Random data `rADVS`.
 #' @docType data
-#'
 #' @usage rADVS
-#'
 #' @keywords datasets internal
-#'
 #' @source internal
 #' @name rADVS
 "rADVS"

--- a/R/default_cdisc_join_keys.R
+++ b/R/default_cdisc_join_keys.R
@@ -1,6 +1,5 @@
 #' List containing default joining keys for `CDISC` datasets
 #'
-#' @details
 #' This data object is created at loading time from `cdisc_datasets/cdisc_datasets.yaml`.
 #'
 #' @name default_cdisc_join_keys

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -1,6 +1,6 @@
 #' Deprecated `TealData` class and related functions
 #'
-#' @description `r lifecycle::badge("deprecated")`\cr
+#' `r lifecycle::badge("deprecated")`\cr
 #' The `TealData` class and associated functions have been deprecated. Use [teal_data()] instead.
 #' See the [Migration guide](https://github.com/insightsengineering/teal/discussions/945) for details.
 #'

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -1,6 +1,8 @@
 #' Deprecated `TealData` class and related functions
 #'
-#' `r lifecycle::badge("deprecated")`\cr
+#' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' The `TealData` class and associated functions have been deprecated. Use [teal_data()] instead.
 #' See the [Migration guide](https://github.com/insightsengineering/teal/discussions/945) for details.
 #'
@@ -333,7 +335,8 @@ get_join_keys <- function(...) {
 #' @rdname col_labels
 #' @include formatters_var_labels.R
 #' @details
-#' `r lifecycle::badge("deprecated")`\cr
+#' `r lifecycle::badge("deprecated")`
+#'
 #' In previous versions of `teal.data` labels were managed with `get_labels()`.
 #' This function is deprecated as of `0.3.1`, use `col_labels` instead.
 #' @export

--- a/R/formatters_var_labels.R
+++ b/R/formatters_var_labels.R
@@ -16,7 +16,8 @@
 #' @return
 #' For `col_labels`, named character vector of variable labels, the names being the corresponding variable names.
 #' If the `label` attribute is missing, the vector elements will be
-#' the variable names themselves if `fill = TRUE` and `NA` if `fill = FALSE`.\cr
+#' the variable names themselves if `fill = TRUE` and `NA` if `fill = FALSE`.
+#'
 #' For `col_labels<-` and `col_relabel`, copy of `x` with variable labels modified.
 #'
 #' @examples

--- a/R/join_key.R
+++ b/R/join_key.R
@@ -1,8 +1,7 @@
 #' Create a relationship between a pair of datasets
 #'
-#' @description `r lifecycle::badge("stable")`
-#'
-#' @description Create a relationship between two datasets, `dataset_1` and `dataset_2`.
+#' `r lifecycle::badge("stable")`\cr
+#' Create a relationship between two datasets, `dataset_1` and `dataset_2`.
 #' By default, this function establishes a directed relationship with `dataset_1` as the parent.
 #' If `dataset_2` is not specified, the function creates a primary key for `dataset_1`.
 #'
@@ -12,9 +11,9 @@
 #' where `names(keys)` maps columns in `dataset_1` corresponding to columns of
 #' `dataset_2` given by the elements of `keys`.
 #'
-#' If unnamed, the same column names are used for both datasets.
+#' * If unnamed, the same column names are used for both datasets.
 #'
-#' If any element of the `keys` vector is empty with a non-empty name, then the name is
+#' * If any element of the `keys` vector is empty with a non-empty name, then the name is
 #' used for both datasets.
 #' @param directed (`logical(1)`) Flag that indicates whether it should create
 #' a parent-child relationship between the datasets.\cr
@@ -23,14 +22,14 @@
 #'
 #' @return object of class `join_key_set` to be passed into `join_keys` function.
 #'
-#' @seealso [join_keys()], [parents()]
-#'
-#' @export
-#'
 #' @examples
 #' join_key("d1", "d2", c("A"))
 #' join_key("d1", "d2", c("A" = "B"))
 #' join_key("d1", "d2", c("A" = "B", "C"))
+#'
+#' @export
+#' @seealso [join_keys()], [parents()]
+#'
 join_key <- function(dataset_1, dataset_2 = dataset_1, keys, directed = TRUE) {
   checkmate::assert_string(dataset_1)
   checkmate::assert_string(dataset_2)

--- a/R/join_key.R
+++ b/R/join_key.R
@@ -12,12 +12,11 @@
 #' @param keys (optionally named `character`) Column mapping between the datasets,
 #' where `names(keys)` maps columns in `dataset_1` corresponding to columns of
 #' `dataset_2` given by the elements of `keys`.
-#'
 #' - If unnamed, the same column names are used for both datasets.
 #' - If any element of the `keys` vector is empty with a non-empty name, then the name is
 #' used for both datasets.
 #' @param directed (`logical(1)`) Flag that indicates whether it should create
-#' a parent-child relationship between the datasets.\cr
+#' a parent-child relationship between the datasets.
 #'  - `TRUE` (default) `dataset_1` is the parent of `dataset_2`;
 #'  - `FALSE` when the relationship is undirected.
 #'

--- a/R/join_key.R
+++ b/R/join_key.R
@@ -11,9 +11,8 @@
 #' where `names(keys)` maps columns in `dataset_1` corresponding to columns of
 #' `dataset_2` given by the elements of `keys`.
 #'
-#' * If unnamed, the same column names are used for both datasets.
-#'
-#' * If any element of the `keys` vector is empty with a non-empty name, then the name is
+#' - If unnamed, the same column names are used for both datasets.
+#' - If any element of the `keys` vector is empty with a non-empty name, then the name is
 #' used for both datasets.
 #' @param directed (`logical(1)`) Flag that indicates whether it should create
 #' a parent-child relationship between the datasets.\cr

--- a/R/join_key.R
+++ b/R/join_key.R
@@ -1,6 +1,8 @@
 #' Create a relationship between a pair of datasets
 #'
-#' `r lifecycle::badge("stable")`\cr
+#' @description
+#' `r lifecycle::badge("stable")`
+#'
 #' Create a relationship between two datasets, `dataset_1` and `dataset_2`.
 #' By default, this function establishes a directed relationship with `dataset_1` as the parent.
 #' If `dataset_2` is not specified, the function creates a primary key for `dataset_1`.

--- a/R/join_keys-c.R
+++ b/R/join_keys-c.R
@@ -1,9 +1,7 @@
 #' @rdname join_keys
 #' @order 4
 #' @export
-#'
 #' @examples
-#'
 #' # Merging multiple `join_keys` objects ---
 #'
 #' jk_merged <- c(
@@ -30,11 +28,8 @@ c.join_keys <- function(...) {
 
 #' @rdname join_keys
 #' @order 4
-#'
 #' @export
-#'
 #' @examples
-#'
 #' # note: merge can be performed with both join_keys and join_key_set
 #'
 #' jk_merged <- c(

--- a/R/join_keys-extract.R
+++ b/R/join_keys-extract.R
@@ -24,6 +24,7 @@
 #' jk["ds1"]
 #' jk[1:2]
 #' jk[c("ds1", "ds2")]
+#'
 `[.join_keys` <- function(x, i, j) {
   if (missing(i) && missing(j)) {
     # because:
@@ -177,7 +178,6 @@
   c(x, join_key(i, j, value, directed))
 }
 
-#' @noRd
 #' @rdname join_keys
 #'
 #' @order 1000
@@ -198,6 +198,8 @@
 #' jk[["ds7"]][["ds7"]] <- NULL # removes key
 #'
 #' jk
+#'
+#' @noRd
 `[[<-.join_keys` <- function(x, i, value) {
   checkmate::assert(
     combine = "or",

--- a/R/join_keys-extract.R
+++ b/R/join_keys-extract.R
@@ -119,7 +119,7 @@
 #' @order 2
 #'
 #' @param directed (`logical(1)`) Flag that indicates whether it should create
-#' a parent-child relationship between the datasets.\cr
+#' a parent-child relationship between the datasets.
 #'  - `TRUE` (default) `dataset_1` is the parent of `dataset_2`;
 #'  - `FALSE` when the relationship is undirected.
 #' @section Functions:

--- a/R/join_keys-names.R
+++ b/R/join_keys-names.R
@@ -1,4 +1,5 @@
 #' The names of a `join_keys` object
+#'
 #' @inheritParams base::`names<-`
 #' @export
 `names<-.join_keys` <- function(x, value) {

--- a/R/join_keys-parents.R
+++ b/R/join_keys-parents.R
@@ -1,6 +1,5 @@
 #' Get and set parents in `join_keys` object
 #'
-#' @description
 #' `parents()` facilitates the creation of dependencies between datasets by
 #' assigning a parent-child relationship.
 #'

--- a/R/join_keys-utils.R
+++ b/R/join_keys-utils.R
@@ -1,4 +1,6 @@
-#' Helper function to assert if two key sets contain incompatible keys
+#' Check Compatibility of keys
+#'
+#' Helper function to assert if two key sets contain incompatible keys.
 #'
 #' @return Returns `TRUE` if successful, otherwise raises error.
 #' @keywords internal
@@ -41,7 +43,9 @@ assert_compatible_keys <- function(join_key_1, join_key_2) {
   return(TRUE)
 }
 
-#' Helper function checks the parent-child relations are valid
+#' Validate parent-child key
+#'
+#' Helper function checks the parent-child relations are valid.
 #'
 #' @param x (`join_keys`) object to assert validity of relations
 #'
@@ -70,6 +74,8 @@ assert_parent_child <- function(x) {
   invisible(x)
 }
 
+#' Verify key set compatibility
+#'
 #' Helper function to ensuring compatibility between two sets of keys
 #'
 #' @return Returns `TRUE` if successful, otherwise raises error.

--- a/R/join_keys.R
+++ b/R/join_keys.R
@@ -35,13 +35,6 @@
 #'
 #' @return `join_keys` object.
 #'
-#' @export
-#'
-#' @seealso [join_key()] for creating `join_keys_set`,
-#' [parents()] for parent operations,
-#' [teal_data()] for `teal_data` constructor _and_
-#' [default_cdisc_join_keys] for default `CDISC` keys.
-#'
 #' @examples
 #' # Creating a new join keys ----
 #'
@@ -54,6 +47,14 @@
 #' )
 #'
 #' jk
+#'
+#' @export
+#'
+#' @seealso [join_key()] for creating `join_keys_set`,
+#' [parents()] for parent operations,
+#' [teal_data()] for `teal_data` constructor _and_
+#' [default_cdisc_join_keys] for default `CDISC` keys.
+#'
 join_keys <- function(...) {
   if (missing(...)) {
     return(new_join_keys())

--- a/R/join_keys.R
+++ b/R/join_keys.R
@@ -22,10 +22,10 @@
 #' - `join_keys(teal_data)`: Returns the `join_keys` object contained in `teal_data` object.
 #' - `join_keys(...)`: Creates a new object with one or more `join_key_set` parameters.
 #'
-#' @param ... (optional)\cr
-#'  either `teal_data` or `join_keys` object to extract `join_keys`, \cr
-#'  or any number of `join_key_set` objects to create `join_keys`, \cr
-#'  or nothing to create an empty `join_keys`
+#' @param ... (optional)
+#' - either `teal_data` or `join_keys` object to extract `join_keys`
+#' - or any number of `join_key_set` objects to create `join_keys`
+#' - or nothing to create an empty `join_keys`
 #' @param value For `x[i, j, directed = TRUE)] <- value` (named/unnamed `character`)
 #' Column mapping between datasets.
 #'

--- a/R/teal_data-class.R
+++ b/R/teal_data-class.R
@@ -47,7 +47,6 @@ setClass(
 
 #' Initialize `teal_data` object
 #'
-#' Initialize `teal_data` object.
 #' @name new_teal_data
 #'
 #' @param data (`named list`) of data objects.

--- a/R/teal_data-show.R
+++ b/R/teal_data-show.R
@@ -1,6 +1,7 @@
 #' Show `teal_data` object
 #'
 #' Prints `teal_data` object.
+#'
 #' @param object (`teal_data`)
 #' @return Input `teal_data` object.
 #' @importFrom methods show

--- a/R/teal_data.R
+++ b/R/teal_data.R
@@ -6,7 +6,8 @@
 #' Universal function to pass data to teal application.
 #'
 #' @param ... any number of objects (presumably data objects) provided as `name = value` pairs.
-#' @param join_keys (`join_keys`) object or a single (`join_key_set`) object\cr
+#' @param join_keys (`join_keys`) object or a single (`join_key_set`) object
+#'
 #'   (optional) object with dataset column relationships used for joining.
 #'   If empty then no joins between pairs of objects
 #' @param code (`character`, `language`) code to reproduce the datasets.

--- a/R/teal_data.R
+++ b/R/teal_data.R
@@ -1,6 +1,8 @@
 #' Comprehensive data integration function for `teal` applications
 #'
-#' `r lifecycle::badge("stable")`\cr
+#' @description
+#' `r lifecycle::badge("stable")`
+#'
 #' Universal function to pass data to teal application.
 #'
 #' @param ... any number of objects (presumably data objects) provided as `name = value` pairs.

--- a/R/teal_data.R
+++ b/R/teal_data.R
@@ -1,6 +1,6 @@
 #' Comprehensive data integration function for `teal` applications
 #'
-#' @description `r lifecycle::badge("stable")`
+#' `r lifecycle::badge("stable")`\cr
 #' Universal function to pass data to teal application.
 #'
 #' @param ... any number of objects (presumably data objects) provided as `name = value` pairs.

--- a/R/testhat-helpers.R
+++ b/R/testhat-helpers.R
@@ -8,18 +8,18 @@
 #' Do not use `all.equal` directly in if expressions—either use `isTRUE(all.equal(....))`
 #' or identical if appropriate.
 #'
-#' @inheritParams base::all.equal
-#' @param ... further arguments for different methods. Not used with `join_keys`.
-#'
-#' @details
 #' The parents attribute comparison tolerates `NULL` and empty lists and will find
 #' no difference.
 #'
 #' The list containing all the relationships is treated like a map and ignores
 #' entries with `NULL` if they exist.
 #'
+#' @inheritParams base::all.equal
+#' @param ... further arguments for different methods. Not used with `join_keys`.
+#'
 #' @seealso [base::all.equal()]
 #' @keywords internal
+#'
 all.equal.join_keys <- function(target, current, ...) {
   .as_map <- function(.x) {
     old_attributes <- attributes(.x)

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -103,7 +103,6 @@ fix_comments <- function(calls) {
 
 #' Create object dependencies graph within parsed code
 #'
-#' @description
 #' Builds dependency graph that identifies dependencies between objects in parsed code.
 #' Helps understand which objects depend on which.
 #'
@@ -131,7 +130,7 @@ code_graph <- function(calls_pd) {
 
 #' Extract object occurrence
 #'
-#' @description Extracts objects occurrence within calls passed by `calls_pd`.
+#' Extracts objects occurrence within calls passed by `calls_pd`.
 #' Also detects which objects depend on which within a call.
 #'
 #' @param calls_pd `list` of `data.frame`s;
@@ -212,9 +211,8 @@ extract_occurrence <- function(calls_pd) {
 
 #' Extract side effects
 #'
-#' @description Extracts all object names from the code that are marked with `@linksto` tag.
+#' Extracts all object names from the code that are marked with `@linksto` tag.
 #'
-#' @details
 #' The code may contain functions calls that create side effects, e.g. modify the environment.
 #' Static code analysis may be insufficient to determine which objects are created or modified by such a function call.
 #' The `@linksto` comment tag is introduced to mark a call as having a (side) effect on one or more objects.

--- a/R/verify.R
+++ b/R/verify.R
@@ -3,8 +3,8 @@
 #' Checks whether code in `teal_data` object reproduces the stored objects.
 #'
 #' If objects created by code in the `@code` slot of `x` are `all_equal` to the contents of the `@env` slot,
-#' the function updates the `@verified` slot to `TRUE` in the returned `teal_data` object. Once verified, the slot
-#' will always be set to `TRUE`.
+#' the function updates the `@verified` slot to `TRUE` in the returned `teal_data` object.
+#' Once verified, the slot will always be set to `TRUE`.
 #' If the `@code` fails to recreate objects in `teal_data@env`, an error is raised.
 #'
 #' @return Input `teal_data` object or error.

--- a/man/TealData.Rd
+++ b/man/TealData.Rd
@@ -166,7 +166,8 @@ get_join_keys(...) <- value
 nothing
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}\cr
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 The \code{TealData} class and associated functions have been deprecated. Use \code{\link[=teal_data]{teal_data()}} instead.
 See the \href{https://github.com/insightsengineering/teal/discussions/945}{Migration guide} for details.
 }

--- a/man/assert_compatible_keys.Rd
+++ b/man/assert_compatible_keys.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/join_keys-utils.R
 \name{assert_compatible_keys}
 \alias{assert_compatible_keys}
-\title{Helper function to assert if two key sets contain incompatible keys}
+\title{Check Compatibility of keys}
 \usage{
 assert_compatible_keys(join_key_1, join_key_2)
 }
@@ -10,6 +10,6 @@ assert_compatible_keys(join_key_1, join_key_2)
 Returns \code{TRUE} if successful, otherwise raises error.
 }
 \description{
-Helper function to assert if two key sets contain incompatible keys
+Helper function to assert if two key sets contain incompatible keys.
 }
 \keyword{internal}

--- a/man/assert_compatible_keys2.Rd
+++ b/man/assert_compatible_keys2.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/join_keys-utils.R
 \name{assert_compatible_keys2}
 \alias{assert_compatible_keys2}
-\title{Helper function to ensuring compatibility between two sets of keys}
+\title{Verify key set compatibility}
 \usage{
 assert_compatible_keys2(x, y)
 }

--- a/man/assert_parent_child.Rd
+++ b/man/assert_parent_child.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/join_keys-utils.R
 \name{assert_parent_child}
 \alias{assert_parent_child}
-\title{Helper function checks the parent-child relations are valid}
+\title{Validate parent-child key}
 \usage{
 assert_parent_child(x)
 }
@@ -13,6 +13,6 @@ assert_parent_child(x)
 \code{join_keys} invisibly
 }
 \description{
-Helper function checks the parent-child relations are valid
+Helper function checks the parent-child relations are valid.
 }
 \keyword{internal}

--- a/man/cdisc_data.Rd
+++ b/man/cdisc_data.Rd
@@ -29,7 +29,8 @@ If \code{check} is true and preprocessing code is empty an error will be thrown.
 A \code{teal_data} object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}\cr
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+
 Function is a wrapper around \code{\link[=teal_data]{teal_data()}} and guesses \code{join_keys}
 for given datasets whose names match ADAM datasets names.
 }

--- a/man/cdisc_data.Rd
+++ b/man/cdisc_data.Rd
@@ -14,7 +14,8 @@ cdisc_data(
 \arguments{
 \item{...}{any number of objects (presumably data objects) provided as \code{name = value} pairs.}
 
-\item{join_keys}{(\code{join_keys}) object or a single (\code{join_key_set}) object\cr
+\item{join_keys}{(\code{join_keys}) object or a single (\code{join_key_set}) object
+
 (optional) object with datasets column names used for joining.
 If empty then it would be automatically derived basing on intersection of datasets primary keys.
 For ADAM datasets it would be automatically derived.}

--- a/man/cdisc_data.Rd
+++ b/man/cdisc_data.Rd
@@ -29,12 +29,12 @@ If \code{check} is true and preprocessing code is empty an error will be thrown.
 A \code{teal_data} object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}\cr
 Function is a wrapper around \code{\link[=teal_data]{teal_data()}} and guesses \code{join_keys}
 for given datasets whose names match ADAM datasets names.
 }
 \details{
-This function checks if there were keys added to all data sets
+This function checks if there were keys added to all data sets.
 }
 \examples{
 data <- cdisc_data(

--- a/man/col_labels.Rd
+++ b/man/col_labels.Rd
@@ -45,7 +45,8 @@ Get or set variable labels in a \code{data.frame}.
 Variable labels can be stored as a \code{label} attribute set on individual variables.
 These functions get or set this attribute, either on all (\code{col_labels}) or some variables (\code{col_relabel}).
 
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}\cr
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 In previous versions of \code{teal.data} labels were managed with \code{get_labels()}.
 This function is deprecated as of \verb{0.3.1}, use \code{col_labels} instead.
 }

--- a/man/col_labels.Rd
+++ b/man/col_labels.Rd
@@ -35,7 +35,8 @@ and value is the new variable label}
 \value{
 For \code{col_labels}, named character vector of variable labels, the names being the corresponding variable names.
 If the \code{label} attribute is missing, the vector elements will be
-the variable names themselves if \code{fill = TRUE} and \code{NA} if \code{fill = FALSE}.\cr
+the variable names themselves if \code{fill = TRUE} and \code{NA} if \code{fill = FALSE}.
+
 For \verb{col_labels<-} and \code{col_relabel}, copy of \code{x} with variable labels modified.
 }
 \description{

--- a/man/default_cdisc_join_keys.Rd
+++ b/man/default_cdisc_join_keys.Rd
@@ -5,8 +5,5 @@
 \alias{default_cdisc_join_keys}
 \title{List containing default joining keys for \code{CDISC} datasets}
 \description{
-List containing default joining keys for \code{CDISC} datasets
-}
-\details{
 This data object is created at loading time from \code{cdisc_datasets/cdisc_datasets.yaml}.
 }

--- a/man/join_key.Rd
+++ b/man/join_key.Rd
@@ -20,7 +20,7 @@ used for both datasets.
 }}
 
 \item{directed}{(\code{logical(1)}) Flag that indicates whether it should create
-a parent-child relationship between the datasets.\cr
+a parent-child relationship between the datasets.
 \itemize{
 \item \code{TRUE} (default) \code{dataset_1} is the parent of \code{dataset_2};
 \item \code{FALSE} when the relationship is undirected.

--- a/man/join_key.Rd
+++ b/man/join_key.Rd
@@ -13,11 +13,11 @@ a primary key for \code{dataset_1} is created.}
 \item{keys}{(optionally named \code{character}) Column mapping between the datasets,
 where \code{names(keys)} maps columns in \code{dataset_1} corresponding to columns of
 \code{dataset_2} given by the elements of \code{keys}.
-
-If unnamed, the same column names are used for both datasets.
-
-If any element of the \code{keys} vector is empty with a non-empty name, then the name is
-used for both datasets.}
+\itemize{
+\item If unnamed, the same column names are used for both datasets.
+\item If any element of the \code{keys} vector is empty with a non-empty name, then the name is
+used for both datasets.
+}}
 
 \item{directed}{(\code{logical(1)}) Flag that indicates whether it should create
 a parent-child relationship between the datasets.\cr
@@ -30,8 +30,7 @@ a parent-child relationship between the datasets.\cr
 object of class \code{join_key_set} to be passed into \code{join_keys} function.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}\cr
 Create a relationship between two datasets, \code{dataset_1} and \code{dataset_2}.
 By default, this function establishes a directed relationship with \code{dataset_1} as the parent.
 If \code{dataset_2} is not specified, the function creates a primary key for \code{dataset_1}.
@@ -40,6 +39,7 @@ If \code{dataset_2} is not specified, the function creates a primary key for \co
 join_key("d1", "d2", c("A"))
 join_key("d1", "d2", c("A" = "B"))
 join_key("d1", "d2", c("A" = "B", "C"))
+
 }
 \seealso{
 \code{\link[=join_keys]{join_keys()}}, \code{\link[=parents]{parents()}}

--- a/man/join_key.Rd
+++ b/man/join_key.Rd
@@ -30,7 +30,8 @@ a parent-child relationship between the datasets.\cr
 object of class \code{join_key_set} to be passed into \code{join_keys} function.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}\cr
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+
 Create a relationship between two datasets, \code{dataset_1} and \code{dataset_2}.
 By default, this function establishes a directed relationship with \code{dataset_1} as the parent.
 If \code{dataset_2} is not specified, the function creates a primary key for \code{dataset_1}.

--- a/man/join_keys.Rd
+++ b/man/join_keys.Rd
@@ -135,6 +135,7 @@ jk <- join_keys(
 
 jk
 
+
 # Getter for join_keys ---
 
 jk["ds1", "ds2"]
@@ -144,6 +145,7 @@ jk["ds1", "ds2"]
 jk["ds1"]
 jk[1:2]
 jk[c("ds1", "ds2")]
+
 
 # Setting a new primary key ---
 
@@ -157,7 +159,6 @@ jk["ds1", "ds4"] <- c("pk1" = "pk4")
 # Removing a key ---
 
 jk["ds5", "ds5"] <- NULL
-
 # Merging multiple `join_keys` objects ---
 
 jk_merged <- c(
@@ -167,7 +168,6 @@ jk_merged <- c(
     join_key("ds3", "ds4", c(pk3 = "pk4_2"))
   )
 )
-
 # note: merge can be performed with both join_keys and join_key_set
 
 jk_merged <- c(

--- a/man/join_keys.Rd
+++ b/man/join_keys.Rd
@@ -45,10 +45,12 @@ join_keys(x) <- value
 \method{print}{join_keys}(x, ...)
 }
 \arguments{
-\item{...}{(optional)\cr
-either \code{teal_data} or \code{join_keys} object to extract \code{join_keys}, \cr
-or any number of \code{join_key_set} objects to create \code{join_keys}, \cr
-or nothing to create an empty \code{join_keys}}
+\item{...}{(optional)
+\itemize{
+\item either \code{teal_data} or \code{join_keys} object to extract \code{join_keys}
+\item or any number of \code{join_key_set} objects to create \code{join_keys}
+\item or nothing to create an empty \code{join_keys}
+}}
 
 \item{x}{(\code{join_keys}) empty object to set the new relationship pairs.
 \code{x} is typically an object of \code{join_keys} class. When called with the \code{join_keys(x)}
@@ -58,7 +60,7 @@ or \code{join_keys(x) <- value} then it can also take a supported class (\code{t
 a character vector, but it can also take numeric, logical, \code{NULL} or missing.}
 
 \item{directed}{(\code{logical(1)}) Flag that indicates whether it should create
-a parent-child relationship between the datasets.\cr
+a parent-child relationship between the datasets.
 \itemize{
 \item \code{TRUE} (default) \code{dataset_1} is the parent of \code{dataset_2};
 \item \code{FALSE} when the relationship is undirected.

--- a/man/new_teal_data.Rd
+++ b/man/new_teal_data.Rd
@@ -23,6 +23,6 @@ Accepts and stores comments also.}
 Needed when non-dataset objects are needed in the \code{env} slot.}
 }
 \description{
-Initialize \code{teal_data} object.
+Initialize \code{teal_data} object
 }
 \keyword{internal}

--- a/man/parents.Rd
+++ b/man/parents.Rd
@@ -40,7 +40,8 @@ For \code{parent(x, dataset_name)} returns \code{NULL} if parent does not exist.
 \description{
 \code{parents()} facilitates the creation of dependencies between datasets by
 assigning a parent-child relationship.
-
+}
+\details{
 Each element is defined by a \code{list} element, where \code{list("child" = "parent")}.
 }
 \section{Methods (by class)}{

--- a/man/rADAE.Rd
+++ b/man/rADAE.Rd
@@ -14,7 +14,7 @@ internal
 rADAE
 }
 \description{
-Random adverse events.
+Random adverse events
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/rADCM.Rd
+++ b/man/rADCM.Rd
@@ -14,7 +14,7 @@ internal
 rADCM
 }
 \description{
-Random concomitant medications.
+Random concomitant medications
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/rADLB.Rd
+++ b/man/rADLB.Rd
@@ -14,7 +14,7 @@ internal
 rADLB
 }
 \description{
-Random lab analysis.
+Random lab analysis
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/rADRS.Rd
+++ b/man/rADRS.Rd
@@ -14,7 +14,7 @@ internal
 rADRS
 }
 \description{
-Random response.
+Random response
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/rADSL.Rd
+++ b/man/rADSL.Rd
@@ -14,7 +14,7 @@ internal
 rADSL
 }
 \description{
-Random patient listing.
+Random patient listing
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/rADTR.Rd
+++ b/man/rADTR.Rd
@@ -14,7 +14,7 @@ internal
 rADTR
 }
 \description{
-Random data \code{rADTR}.
+Random data \code{rADTR}
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/rADTTE.Rd
+++ b/man/rADTTE.Rd
@@ -14,7 +14,7 @@ internal
 rADTTE
 }
 \description{
-Random time to event analysis dataset.
+Random time to event analysis dataset
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/rADVS.Rd
+++ b/man/rADVS.Rd
@@ -14,7 +14,7 @@ internal
 rADVS
 }
 \description{
-Random data \code{rADVS}.
+Random data \code{rADVS}
 }
 \keyword{datasets}
 \keyword{internal}

--- a/man/teal_data.Rd
+++ b/man/teal_data.Rd
@@ -14,7 +14,8 @@ teal_data(
 \arguments{
 \item{...}{any number of objects (presumably data objects) provided as \code{name = value} pairs.}
 
-\item{join_keys}{(\code{join_keys}) object or a single (\code{join_key_set}) object\cr
+\item{join_keys}{(\code{join_keys}) object or a single (\code{join_key_set}) object
+
 (optional) object with dataset column relationships used for joining.
 If empty then no joins between pairs of objects}
 

--- a/man/teal_data.Rd
+++ b/man/teal_data.Rd
@@ -28,7 +28,7 @@ If \code{check} is true and preprocessing code is empty an error will be thrown.
 A \code{teal_data} object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}\cr
 Universal function to pass data to teal application.
 }
 \examples{

--- a/man/teal_data.Rd
+++ b/man/teal_data.Rd
@@ -28,7 +28,8 @@ If \code{check} is true and preprocessing code is empty an error will be thrown.
 A \code{teal_data} object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}\cr
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+
 Universal function to pass data to teal application.
 }
 \examples{

--- a/man/verify.Rd
+++ b/man/verify.Rd
@@ -19,8 +19,8 @@ Checks whether code in \code{teal_data} object reproduces the stored objects.
 }
 \details{
 If objects created by code in the \verb{@code} slot of \code{x} are \code{all_equal} to the contents of the \verb{@env} slot,
-the function updates the \verb{@verified} slot to \code{TRUE} in the returned \code{teal_data} object. Once verified, the slot
-will always be set to \code{TRUE}.
+the function updates the \verb{@verified} slot to \code{TRUE} in the returned \code{teal_data} object.
+Once verified, the slot will always be set to \code{TRUE}.
 If the \verb{@code} fails to recreate objects in \code{teal_data@env}, an error is raised.
 }
 \examples{


### PR DESCRIPTION
following discussion on https://github.com/insightsengineering/teal.slice/pull/506#discussion_r1450620331 

I refined the rd documentation by removing the `@description` and` @details` tags,  And using an explicit `@description `tag to prevent the second and subsequent paragraphs from being turned into the `@details`. I followed the guide from https://r-pkgs.org/man.html#title-description-details.
