### PR TITLE
238 assign function with a variable as an input 

### DIFF
--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -268,7 +268,7 @@ extract_occurrence <- function(calls_pd, code) {
   # Then include x's value.
   if (length(occurrence) >= 2) {
     for (i in 2:length(occurrence)) {
-      if (occurrence[[i]][1] == "<-") {
+      if (length(occurrence[[i]]) && occurrence[[i]][1] == "<-") {
         name <- occurrence[[i]][2]
         env <- new.env()
         eval(code[1:(i - 1)], envir = env)

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -271,7 +271,7 @@ extract_occurrence <- function(calls_pd, code) {
       if (occurrence[[i]][1] == "<-") {
         name <- occurrence[[i]][2]
         env <- new.env()
-        eval(code[1:(i-1)], envir = env)
+        eval(code[1:(i - 1)], envir = env)
         value <- get(name, envir = env)
         occurrence[[i]] <- c(value, occurrence[[i]])
       }

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -352,10 +352,10 @@ testthat::test_that(
     testthat::expect_identical(
       get_code(tdata, datanames = "classes"),
       paste("iris2 <- iris[1:5, ]",
-            "iris_head <- head(iris)",
-            "iris3 <- iris_head[1, ]",
-            "classes <- lapply(iris2, class)",
-            sep = "\n"
+        "iris_head <- head(iris)",
+        "iris3 <- iris_head[1, ]",
+        "classes <- lapply(iris2, class)",
+        sep = "\n"
       )
     )
   }
@@ -486,11 +486,11 @@ testthat::test_that("get_code with datanames understands $ usage and do not trea
   testthat::expect_identical(
     get_code(tdata, datanames = "a"),
     paste("x <- data.frame(a = 1:3)",
-          "a <- data.frame(y = 1:3)",
-          "a$x <- a$y",
-          "a$x <- a$x + 2",
-          "a$x <- x$a",
-          sep = "\n"
+      "a <- data.frame(y = 1:3)",
+      "a$x <- a$y",
+      "a$x <- a$x + 2",
+      "a$x <- x$a",
+      sep = "\n"
     )
   )
 })


### PR DESCRIPTION
Close #238

# Overview

`get_code` now properly detects dependencies in static code analysis if in `assign` the `x` parameter was passed as a variable.

How it was before

```r
code <- c("z <- 'b'", "assign(z, 5)")
tdata <- eval_code(teal_data(), code)
get_code(tdata, datanames = "b")

> character(0)
```

How it is now

```r
code <- c("z <- 'b'", "assign(z, 5)")
tdata <- eval_code(teal_data(), code)
get_code(tdata, datanames = "b")

> [1] "z <- \"b\"\nassign(z, 5)"
```

# Notes

To allow detection of variables in `assign` function we do **needed to actually evaluate the code**. This might not always be possible (due to some locale specifics or lacking credentials) or can take a long time. If you see any other way to do that without evaluating the code, I would appreciate any ideas. From the other hand, we evaluate the code because the variable passed into `assign(x = ` could be a result of multiple text operations on it. If this is only text operations then it could be fast, however it also runs all other code lines that can refer to long data processing, or some authorization.

# Questions

## Question 1
Should we remove the check in `get_code_dependency()` that detects if passed `names` correspond to the existing object names within the code? This is already a long block of lines, which is incomplete as it does not YET cover the case of variable being passed to `assign(x = ` function (x parameter). 
```r
code <- c("z <- 'b'", "assign(z, 5)")
tdata <- eval_code(teal_data(), code)
get_code(tdata, datanames = "b")

> [1] "z <- \"b\"\nassign(z, 5)"
In get_code_dependency(object@code, datanames) :
  Object(s) not found in code: b
```
https://github.com/insightsengineering/teal.data/blob/655ea9edf4d5c0cf4dc821105da8ca3051f6fd07/R/utils-get_code_dependency.R#L40-L52

## Question 2
Since we are doing so much with `assign` detection in `extract_occurrence` I wonder if we should create a separate function for `assign` evaluation, to make `extract_occurrence` easier to grasp. This could contain below lines
https://github.com/insightsengineering/teal.data/blob/655ea9edf4d5c0cf4dc821105da8ca3051f6fd07/R/utils-get_code_dependency.R#L206-L231