### PR TITLE
Fix `extract_calls` for calls with `;`

### DIFF
--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -100,6 +100,7 @@ find_call <- function(call_pd, text) {
 #' @noRd
 extract_calls <- function(pd) {
   calls <- lapply(pd[pd$parent == 0, "id"], get_children, pd = pd)
+  calls <- Filter(Negate(is.null), calls)
   fix_comments(calls)
 }
 

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -166,6 +166,16 @@ testthat::test_that("get_code returns result of length 1 for non-empty input", {
   testthat::expect_length(get_code(tdata1, deparse = TRUE), 1)
 })
 
+testthat::test_that("get_code does not break if code is separated by ;", {
+  code <- c(
+    "a <- 1;a <- a + 1"
+  )
+  tdata <- eval_code(teal_data(), code)
+  testthat::expect_identical(
+    get_code(tdata, datanames = "a"),
+    gsub(";", "\n", code, fixed = TRUE)
+  )
+})
 
 # assign ----------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes code analysis that has `;` in it. Cases like `code  <- "d <- 'a';assign(value = 'test_text', x = d)"` break `extract_calls()`