### PR TITLE
Registers `all.equal.join_keys` only for testing

### DIFF
--- a/tests/testthat/helper-all.equal.R
+++ b/tests/testthat/helper-all.equal.R
@@ -1,2 +1,4 @@
-# covr package doesn't detect the .S3method if it is declared within R/ folder
-.S3method("all.equal", "join_keys", all.equal.join_keys)
+# Register method for testthat::expect_identical to compare join_keys
+if (nzchar(Sys.getenv("TESTTHAT"))) {
+  registerS3method("all.equal", "join_keys", all.equal.join_keys)
+}


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #256 

#### Alternative solution

Export the method to compare `join_keys` (method ignores internal list order, NULL elements and will check attributes)

#### Changes description

- Registers S3 method only during testing. `devtools::run_examples()` was sourcing a {testthat} helper file
