### PR TITLE
267 fix `@linksto` tag with `eval()` in last line of the evaluated code for `get_code`

### DIFF
--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -138,7 +138,7 @@ fix_comments <- function(calls) {
       }
     }
   }
-  Filter(function(x) nrow(x) != 0, calls)
+  Filter(nrow, calls)
 }
 
 # code_graph ----

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -99,7 +99,15 @@ find_call <- function(call_pd, text) {
 #' @keywords internal
 #' @noRd
 extract_calls <- function(pd) {
-  calls <- lapply(pd[pd$parent == 0, "id"], get_children, pd = pd)
+  calls <- lapply(
+    pd[pd$parent == 0, "id"],
+    function(parent) {
+      rbind(
+        pd[pd$id == parent, c("token", "text", "id", "parent")],
+        get_children(pd = pd, parent = parent)
+      )
+    }
+  )
   calls <- Filter(Negate(is.null), calls)
   fix_comments(calls)
 }
@@ -130,7 +138,7 @@ fix_comments <- function(calls) {
       }
     }
   }
-  calls
+  Filter(function(x) nrow(x) != 0, calls)
 }
 
 # code_graph ----

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -266,6 +266,19 @@ testthat::test_that("@linksto tag indicate affected object if object is assigned
 
 # @linksto ---------------------------------------------------------------------------------------------------------
 
+testthat::test_that("get_code does not break if @linksto is with eval in last line", {
+  code <- c(
+    "expr <- quote(x <- x + 1)",
+    "x <- 0",
+    "eval(expr) #@linksto x"
+  )
+  tdata <- eval_code(teal_data(), code)
+  testthat::expect_identical(
+    get_code(tdata, datanames = "x"),
+    paste(gsub(" #@linksto x", "", code, fixed = TRUE), collapse = "\n")
+  )
+})
+
 testthat::test_that("@linksto cause to return this line for affected binding", {
   code <- "
   a <- 1 # @linksto b

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -267,7 +267,10 @@ testthat::test_that("detects function usage of the assignment operator", {
 
 # @linksto ---------------------------------------------------------------------------------------------------------
 
-testthat::test_that("get_code does not break if @linksto is with eval in last line", {
+testthat::test_that("get_code does not break if @linksto is put in the last line", {
+  # In some cases R parses comment as a separate expression so the comment is not 
+  # directly associated with this line of code. This situation occurs when `eval` is in the last
+  # line of the code. Other cases are not known but are highly probable.
   code <- c(
     "expr <- quote(x <- x + 1)",
     "x <- 0",


### PR DESCRIPTION
Close #267 

Used @gogonzo solution from this PR to fix this https://github.com/insightsengineering/teal.data/pull/262/files#diff-66a61facc4f5ca86215d63af40e2645b364950439051784916316ef78d5073c8R102-R110