### PR TITLE
Revert quote detection from 265

### DIFF
--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -215,10 +215,6 @@ extract_occurrence <- function(calls_pd) {
         sym <- call_pd[assign_call + pos, "text"]
         return(c(gsub("^['\"]|['\"]$", "", sym), "<-"))
       }
-      quote_call <- find_call(call_pd, "quote")
-      if (quote_call) {
-        call_pd <- call_pd[-c(1:quote_call), ]
-      }
 
       # What occurs in a function body is not tracked.
       x <- call_pd[!is_in_function(call_pd), ]

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -196,7 +196,7 @@ testthat::test_that("get_code does not break if code uses quote", {
   tdata <- eval_code(teal_data(), code)
   testthat::expect_identical(
     get_code(tdata, datanames = "x"),
-    paste(code[1:2], collapse = "\n")
+    code[2]
   )
 })
 


### PR DESCRIPTION
We went too far with the assumption of automated detection in here https://github.com/insightsengineering/teal.data/pull/266#issuecomment-1906057027

Reverting this one