### PR TITLE
Run verification check when check is `TRUE`

### DIFF
--- a/R/teal_data.R
+++ b/R/teal_data.R
@@ -52,10 +52,14 @@ teal_data <- function(...,
     if (length(data_objects) > 0 && !checkmate::test_names(names(data_objects), type = "named")) {
       stop("Dot (`...`) arguments on `teal_data()` must be named.")
     }
-    new_teal_data(
+    data <- new_teal_data(
       data = data_objects,
       code = code,
       join_keys = join_keys
     )
   }
+  if (check) {
+    data <- verify(data)
+  }
+  return(data)
 }

--- a/tests/testthat/test-cdisc_data.R
+++ b/tests/testthat/test-cdisc_data.R
@@ -1,7 +1,11 @@
 testthat::test_that("cdisc_data returns teal_data object for objects different than old api", {
   adsl_raw <- as.data.frame(as.list(stats::setNames(nm = default_cdisc_join_keys["ADSL", "ADSL"])))
   testthat::expect_s4_class(
-    teal_data(adsl = adsl_raw, check = TRUE),
+    cdisc_data(adsl = adsl_raw, check = FALSE),
+    "teal_data"
+  )
+  testthat::expect_s4_class(
+    cdisc_data(i = iris, code = "i <- iris", check = TRUE),
     "teal_data"
   )
 })


### PR DESCRIPTION
Part of https://github.com/insightsengineering/teal/issues/1069

Please make sure that you also use the `teal` branch `1069-fix-code-warnings-when-data-is-verified@main` for testing the example from the issue.