### PR TITLE
Handle both named and unnamed inputs in `col_labels`

### DIFF
--- a/R/formatters_var_labels.R
+++ b/R/formatters_var_labels.R
@@ -43,7 +43,9 @@ col_labels <- function(x, fill = FALSE) {
     return(character(0L))
   }
 
-  labels <- lapply(x, attr, "label")
+  labels <- lapply(x, function(col) {
+    unname(attr(col, "label"))
+  })
 
   nulls <- vapply(labels, is.null, logical(1L))
   if (any(nulls)) {


### PR DESCRIPTION
Fixes the bug reported [here](https://github.com/insightsengineering/teal.goshawk/pull/256#issuecomment-1941767247)

Why is this behavior?
```r
library(scda)
library(scda.2022)
library(formatters)
ADSL <- synthetic_cdisc_data("latest")$adsl
print(teal.data::col_labels(ADSL)) # This produces a valid column labels
var_labels(ADSL) <- teal.data::col_labels(ADSL)
print(teal.data::col_labels(ADSL)) # After the var_labels modifies the labels it's invalid now
```

App code to reproduce the error:
```r
library(teal.modules.general)
data <- within(teal_data(), {
  library(scda)
  library(scda.2022)
  library(formatters)
  ADSL <- synthetic_cdisc_data("latest")$adsl
  adsl_labels <- teal.data::col_labels(ADSL)
  var_labels(ADSL) <- adsl_labels
})
datanames(data) <- "ADSL"

app <- teal::init(
  data = data,
  modules = tm_variable_browser(label = "Variable Browser")
)

shinyApp(app$ui, app$server)
```