### PR TITLE
minor improvements to label functions

### DIFF
--- a/R/formatters_var_labels.R
+++ b/R/formatters_var_labels.R
@@ -73,10 +73,14 @@ col_labels <- function(x, fill = FALSE) {
     .var.name = "Length of value is equal to the number of columns"
   )
 
-  if (is.null(names(value))) {
-    names(value) <- names(x)
-  }
-  x[names(value)] <- mapply(`attr<-`, x = x[names(value)], which = "label", value = value, SIMPLIFY = FALSE)
+  varnames <-
+    if (is.null(names(value))) {
+      names(x)
+    } else {
+      names(value)
+    }
+
+  x[varnames] <- mapply(`attr<-`, x = x[varnames], which = "label", value = value, SIMPLIFY = FALSE)
   x
 }
 
@@ -87,12 +91,12 @@ col_relabel <- function(x, ...) {
   if (missing(...)) {
     return(x)
   }
-  dots <- list(...)
-  varnames <- names(dots)
+  value <- list(...)
+  varnames <- names(value)
 
   checkmate::assert_subset(varnames, names(x), .var.name = "names of ...")
-  lapply(dots, checkmate::assert_string, .var.name = "element of ...")
+  lapply(value, checkmate::assert_string, .var.name = "element of ...")
 
-  x[varnames] <- mapply(`attr<-`, x = x[varnames], which = "label", value = dots, SIMPLIFY = FALSE, USE.NAMES = FALSE)
+  x[varnames] <- mapply(`attr<-`, x = x[varnames], which = "label", value = value, SIMPLIFY = FALSE)
   x
 }

--- a/R/formatters_var_labels.R
+++ b/R/formatters_var_labels.R
@@ -55,7 +55,7 @@ col_labels <- function(x, fill = FALSE) {
       }
   }
 
-  unlist(labels, recursive = FALSE)
+  unlist(labels)
 }
 
 #' @rdname col_labels

--- a/R/formatters_var_labels.R
+++ b/R/formatters_var_labels.R
@@ -55,11 +55,6 @@ col_labels <- function(x, fill = FALSE) {
       }
   }
 
-  not_char <- !vapply(labels, checkmate::test_string, logical(1L), na.ok = TRUE)
-  if (any(not_char)) {
-    stop("labels for variables ", toString(names(not_char[not_char])), "are not character strings")
-  }
-
   unlist(labels, recursive = FALSE)
 }
 
@@ -77,6 +72,7 @@ col_labels <- function(x, fill = FALSE) {
     if (is.null(names(value))) {
       names(x)
     } else {
+      checkmate::assert_set_equal(names(value), names(x), .var.name = "column names")
       names(value)
     }
 

--- a/tests/testthat/test-formatters_var_labels.R
+++ b/tests/testthat/test-formatters_var_labels.R
@@ -49,7 +49,7 @@ testthat::test_that("col_labels<- value names must be same as variable names", {
   iris_df <- utils::head(iris, 2)
   testthat::expect_error(
     col_labels(iris_df) <- stats::setNames(as.character(1:5), toupper(names(iris_df))),
-    "undefined columns selected"
+    "Assertion on 'column names' failed: Must be a permutation of set"
   )
 })
 
@@ -85,7 +85,7 @@ testthat::test_that("col_labels<- matches labels to variables by names of values
 
 
 # col_relabel ----
-test_that("col_relabel correctly changes column labels in a data frame", {
+testthat::test_that("col_relabel correctly changes column labels in a data frame", {
   iris_df <- utils::head(iris, 2)
   iris_df <- col_relabel(iris_df, Sepal.Length = "Sepal Length of iris flower")
   testthat::expect_identical(
@@ -94,14 +94,14 @@ test_that("col_relabel correctly changes column labels in a data frame", {
   )
 })
 
-test_that("col_relabel throws an error for non-existent columns", {
+testthat::test_that("col_relabel throws an error for non-existent columns", {
   testthat::expect_error(
     col_relabel(iris, NonExistentColumn = "Label"),
     "Must be a subset of \\{.*\\}, but has additional elements \\{'NonExistentColumn'\\}"
   )
 })
 
-test_that("col_relabel returns the original data.frame when no new labels are specified", {
+testthat::test_that("col_relabel returns the original data.frame when no new labels are specified", {
   iris_df <- col_relabel(iris)
   testthat::expect_equal(iris_df, iris)
 })

--- a/tests/testthat/test-formatters_var_labels.R
+++ b/tests/testthat/test-formatters_var_labels.R
@@ -1,3 +1,4 @@
+# col_labels ----
 testthat::test_that("col_labels accepts an empty data.frame", {
   testthat::expect_no_error(col_labels(data.frame()))
 })
@@ -20,8 +21,72 @@ testthat::test_that("col_labels returns a vector of column names when fill = TRU
   )
 })
 
+
+# col_labels ----
+testthat::test_that("col_labels<- value accepts character vector", {
+  iris_df <- utils::head(iris, 2)
+  testthat::expect_error(
+    col_labels(iris_df) <- 1:5,
+    "Assertion on 'value' failed: Must be of type 'character'"
+  )
+  testthat::expect_no_error(col_labels(iris_df) <- as.character(1:5))
+})
+
+testthat::test_that("col_labels<- value must be same length as x", {
+  iris_df <- utils::head(iris, 2)
+  testthat::expect_error(
+    col_labels(iris_df) <- as.character(1:4),
+    "Assertion on 'Length of value is equal to the number of columns' failed"
+  )
+})
+
+testthat::test_that("col_labels<- value accepts named vector", {
+  iris_df <- utils::head(iris, 2)
+  testthat::expect_no_error(col_labels(iris_df) <- stats::setNames(as.character(1:5), names(iris)))
+})
+
+testthat::test_that("col_labels<- value names must be same as variable names", {
+  iris_df <- utils::head(iris, 2)
+  testthat::expect_error(
+    col_labels(iris_df) <- stats::setNames(as.character(1:5), toupper(names(iris_df))),
+    "undefined columns selected"
+  )
+})
+
+testthat::test_that("col_labels<- sets variable labels when passed unnamed character vector", {
+  iris_df <- utils::head(iris, 2)
+  labels <- paste("label for", names(iris_df))
+  col_labels(iris_df) <- labels
+  testthat::expect_identical(
+    col_labels(iris_df),
+    stats::setNames(labels, names(iris_df))
+  )
+})
+
+testthat::test_that("col_labels<- sets variable labels when passed named character vector", {
+  iris_df <- utils::head(iris, 2)
+  labels <- stats::setNames(paste("label for", names(iris_df)), names(iris_df))
+  col_labels(iris_df) <- labels
+  testthat::expect_identical(
+    col_labels(iris_df),
+    labels
+  )
+})
+
+testthat::test_that("col_labels<- matches labels to variables by names of values argument", {
+  iris_df <- utils::head(iris, 2)
+  labels <- stats::setNames(paste("label for", names(iris_df)), names(iris_df))
+  col_labels(iris_df) <- rev(labels)
+  testthat::expect_identical(
+    col_labels(iris_df),
+    labels
+  )
+})
+
+
+# col_relabel ----
 test_that("col_relabel correctly changes column labels in a data frame", {
-  iris_df <- iris
+  iris_df <- utils::head(iris, 2)
   iris_df <- col_relabel(iris_df, Sepal.Length = "Sepal Length of iris flower")
   testthat::expect_identical(
     col_labels(iris_df),


### PR DESCRIPTION
Adds unit tests for `col_labels<-`.
Slightly changes bodies of `col_labels<-` and `col_relabel` so that they are more similar.
Improved argument checks.