### PR TITLE
docs: vignettes: add `purl=FALSE` to the chunk producing error

### DIFF
--- a/vignettes/teal-data-reproducibility.Rmd
+++ b/vignettes/teal-data-reproducibility.Rmd
@@ -75,7 +75,7 @@ data_right <- teal_data(
 
 #### unverified
 
-```{r, message=FALSE, error=TRUE}
+```{r, message=FALSE, error=TRUE, purl=FALSE}
 data_wrong <- teal_data(
   data = data,
   code = quote({


### PR DESCRIPTION
fix verdepcheck errors: https://github.com/insightsengineering/teal.data/actions/runs/8585969509/job/23527932989

this currently fails with the below:
```
* checking running R code from vignettes ...
  ‘join-keys.Rmd’ using ‘UTF-8’... OK
  ‘teal-data-reproducibility.Rmd’ using ‘UTF-8’... failed
  ‘teal-data.Rmd’ using ‘UTF-8’... OK
 ERROR
Errors in running code in vignettes:
when running code in ‘teal-data-reproducibility.Rmd’
  ...
+     data <- data.frame(x = 11:20)
+ }))
> verify(data_wrong)
  When sourcing ‘teal-data-reproducibility.R’:
Error: Code verification failed.
Object(s) recreated with code that have different structure in data_wrong:
  • data
Execution halted
```

This is also present if you just run `rcmdcheck::rcmdcheck()` (i.e. without verdepcheck).

Follow the guidelines from [here](https://r-pkgs.org/R-CMD-check.html#:~:text=Checking%20running%20R%20code%20from%20vignettes)
> If you want to deliberately execute errors (to show the user what failure looks like), make sure the chunk has `error = TRUE, purl = FALSE`.

I will be running the pipeline manually. You can track its status here: https://github.com/insightsengineering/teal.data/actions/workflows/scheduled.yaml?query=branch%3Afix_verdepcheck