### PR TITLE
return ls(@env) if @datanames not specified

### DIFF
--- a/R/join_keys.R
+++ b/R/join_keys.R
@@ -142,7 +142,6 @@ join_keys.teal_data <- function(...) {
 #' join_keys(td)
 `join_keys<-.teal_data` <- function(x, value) {
   join_keys(x@join_keys) <- value
-  datanames(x) <- x@datanames # datanames fun manages some exceptions
   x
 }
 

--- a/R/teal_data-class.R
+++ b/R/teal_data-class.R
@@ -82,8 +82,6 @@ new_teal_data <- function(data,
   new_env <- rlang::env_clone(list2env(data), parent = parent.env(.GlobalEnv))
   lockEnvironment(new_env, bindings = TRUE)
 
-  datanames <- .get_sorted_datanames(datanames = datanames, join_keys = join_keys, env = new_env)
-
   methods::new(
     "teal_data",
     env = new_env,

--- a/man/datanames.Rd
+++ b/man/datanames.Rd
@@ -26,10 +26,8 @@ Get or set the value of the \code{datanames} slot.
 }
 \details{
 The \verb{@datanames} slot in a \code{teal_data} object specifies which of the variables stored in its environment
-(the \verb{@env} slot) are data sets to be taken into consideration.
-The contents of \verb{@datanames} can be specified upon creation and default to all variables in \verb{@env}.
-Variables created later, which may well be data sets, are not automatically considered such.
-Use this function to update the slot.
+(the \verb{@env} slot) are data sets to be taken into consideration. If not set explicitly, then \code{\link[=datanames]{datanames()}} returns
+all variable names from \verb{@env}.
 }
 \examples{
 td <- teal_data(iris = iris)

--- a/tests/testthat/test-datanames.R
+++ b/tests/testthat/test-datanames.R
@@ -10,6 +10,12 @@ testthat::test_that("variables not in @datanames are omitted", {
   testthat::expect_identical(datanames(td), c("i", "m"))
 })
 
+testthat::test_that("datanames() returns all object names from @env if @datasets not specified", {
+  td <- teal_data(i = iris, m = mtcars)
+  td <- within(td, f <- faithful)
+  testthat::expect_identical(datanames(td), c("i", "m"))
+})
+
 # set ----
 testthat::test_that("datanames can set value of @datanames", {
   td <- teal_data(i = iris, m = mtcars)


### PR DESCRIPTION
`teal.data::datanames()` should return `ls(@env)` if is not specified. IMO `datanames<-` function shouldn't be supported and determining module's datanames should be done through `module$datanames` only. `teal.data::datanames` has been created only for teal-app to limit datanames. For `teal.data` package it doesn't have any usage at all and should be deprecated in the future. I think that we should use `ls(get_env(<teal_data>))` instead in teal.
