### PR TITLE
Fix roxygen2 issue with all/all.equal ambiguity

### DIFF
--- a/R/testhat-helpers.R
+++ b/R/testhat-helpers.R
@@ -19,7 +19,8 @@
 #'
 #' @seealso [base::all.equal()]
 #' @keywords internal
-#'
+#' @method all.equal join_keys
+#' @exportS3Method all.equal join_keys
 all.equal.join_keys <- function(target, current, ...) {
   .as_map <- function(.x) {
     old_attributes <- attributes(.x)


### PR DESCRIPTION
You are affected by https://github.com/r-lib/roxygen2/issues/1587. Came across your package while looking for a solution, so sharing what I found.