### PR TITLE
Allow non-standard datanames in code dependency

### DIFF
--- a/R/teal_data-get_code.R
+++ b/R/teal_data-get_code.R
@@ -108,7 +108,9 @@ setMethod("get_code", signature = "teal_data", definition = function(object, dep
   checkmate::assert_flag(deparse)
 
   # Normalize in case special it is backticked
-  datanames <- gsub("^`(.*)`$", "\\1", datanames)
+  if (!is.null(datanames)) {
+    datanames <- gsub("^`(.*)`$", "\\1", datanames)
+  }
 
   code <- if (!is.null(datanames)) {
     get_code_dependency(object@code, datanames, ...)

--- a/R/teal_data-get_code.R
+++ b/R/teal_data-get_code.R
@@ -107,6 +107,9 @@ setMethod("get_code", signature = "teal_data", definition = function(object, dep
   checkmate::assert_character(datanames, min.len = 1L, null.ok = TRUE)
   checkmate::assert_flag(deparse)
 
+  # Normalize in case special it is backticked
+  datanames <- gsub("^`(.*)`$", "\\1", datanames)
+
   code <- if (!is.null(datanames)) {
     get_code_dependency(object@code, datanames, ...)
   } else {

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -42,7 +42,9 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
 
   code <- parse(text = code, keep.source = TRUE)
   pd <- utils::getParseData(code)
+  pd <- normalize_pd(pd)
   calls_pd <- extract_calls(pd)
+
 
   if (check_names) {
     # Detect if names are actually in code.
@@ -175,7 +177,7 @@ fix_arrows <- function(calls) {
 sub_arrows <- function(call) {
   checkmate::assert_data_frame(call)
   map <- data.frame(
-    row.names = c("`<-`", "`<<-`", "`=`"),
+    row.names = c("<-", "<<-", "="),
     token = rep("LEFT_ASSIGN", 3),
     text = rep("<-", 3)
   )
@@ -380,9 +382,6 @@ extract_side_effects <- function(calls_pd) {
 #' @keywords internal
 #' @noRd
 graph_parser <- function(x, graph) {
-  # normalize x to remove surrounding backticks
-  x <- gsub("^`(.*)`$", "\\1", x)
-  graph <- lapply(graph, function(call) gsub("^`(.*)`$", "\\1", call))
   occurrence <- vapply(
     graph,
     function(call) {
@@ -437,4 +436,20 @@ detect_libraries <- function(calls_pd) {
       logical(1)
     )
   )
+}
+
+#' Normalize parsed data removing backticks from symbols
+#'
+#' @param pd `data.frame` resulting from `utils::getParseData()` call.
+#'
+#' @return `data.frame` with backticks removed from `text` column for `SYMBOL` tokens.
+#'
+#' @keywords internal
+#' @noRd
+normalize_pd <- function(pd) {
+  # Remove backticks from SYMBOL tokens
+  symbol_index <- grepl("^SYMBOL.*$", pd$token)
+  pd[symbol_index, "text"] <- gsub("^`(.*)`$", "\\1", pd[symbol_index, "text"])
+
+  pd
 }

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -381,8 +381,8 @@ extract_side_effects <- function(calls_pd) {
 #' @noRd
 graph_parser <- function(x, graph) {
   # normalize x to remove surrounding backticks
-  x <- gsub("^`|`$", "", x)
-  graph <- lapply(graph, function(call) gsub("^`|`$", "", call))
+  x <- gsub("^`(.*)`$", "\\1", x)
+  graph <- lapply(graph, function(call) gsub("^`(.*)`$", "\\1", call))
   occurrence <- vapply(
     graph,
     function(call) {

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -297,7 +297,7 @@ extract_occurrence <- function(calls_pd) {
 
       # What occurs in a function body is not tracked.
       x <- call_pd[!is_in_function(call_pd), ]
-      sym_cond <- which(x$token %in% c("SYMBOL", "SYMBOL_FUNCTION_CALL"))
+      sym_cond <- which(x$token %in% c("SPECIAL", "SYMBOL", "SYMBOL_FUNCTION_CALL"))
 
       if (length(sym_cond) == 0) {
         return(character(0L))
@@ -380,10 +380,12 @@ extract_side_effects <- function(calls_pd) {
 #' @keywords internal
 #' @noRd
 graph_parser <- function(x, graph) {
+  # normalize x to remove surrounding backticks
+  x <- gsub("^`|`$", "", x)
   occurrence <- vapply(
     graph, function(call) {
       ind <- match("<-", call, nomatch = length(call) + 1L)
-      x %in% call[seq_len(ind - 1L)]
+      x %in% gsub("^`|`$", "", call[seq_len(ind - 1L)])
     },
     logical(1)
   )

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -55,7 +55,7 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
       ass_str <- gsub("^['\"]|['\"]$", "", ass_str)
       symbols <- c(ass_str, symbols)
     }
-    if (!all(sapply(names, as.name) %in% unique(symbols))) {
+    if (!all(names %in% unique(symbols))) {
       warning("Object(s) not found in code: ", toString(setdiff(names, symbols)))
     }
   }

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -53,7 +53,7 @@ get_code_dependency <- function(code, names, check_names = TRUE) {
       ass_str <- gsub("^['\"]|['\"]$", "", ass_str)
       symbols <- c(ass_str, symbols)
     }
-    if (!all(names %in% unique(symbols))) {
+    if (!all(sapply(names, as.name) %in% unique(symbols))) {
       warning("Object(s) not found in code: ", toString(setdiff(names, symbols)))
     }
   }

--- a/R/utils-get_code_dependency.R
+++ b/R/utils-get_code_dependency.R
@@ -382,10 +382,12 @@ extract_side_effects <- function(calls_pd) {
 graph_parser <- function(x, graph) {
   # normalize x to remove surrounding backticks
   x <- gsub("^`|`$", "", x)
+  graph <- lapply(graph, function(call) gsub("^`|`$", "", call))
   occurrence <- vapply(
-    graph, function(call) {
+    graph,
+    function(call) {
       ind <- match("<-", call, nomatch = length(call) + 1L)
-      x %in% gsub("^`|`$", "", call[seq_len(ind - 1L)])
+      x %in% call[seq_len(ind - 1L)]
     },
     logical(1)
   )

--- a/man/cdisc_data.Rd
+++ b/man/cdisc_data.Rd
@@ -29,7 +29,7 @@ Use \code{\link[=verify]{verify()}} to verify code reproducibility .}
 A \code{teal_data} object.
 }
 \description{
-\verb{r lifecycle::badge("stable")}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
 Function is a wrapper around \code{\link[=teal_data]{teal_data()}} and guesses \code{join_keys}
 for given datasets whose names match ADAM datasets names.

--- a/man/cdisc_data.Rd
+++ b/man/cdisc_data.Rd
@@ -29,7 +29,7 @@ Use \code{\link[=verify]{verify()}} to verify code reproducibility .}
 A \code{teal_data} object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
+\verb{r lifecycle::badge("stable")}
 
 Function is a wrapper around \code{\link[=teal_data]{teal_data()}} and guesses \code{join_keys}
 for given datasets whose names match ADAM datasets names.

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -700,16 +700,16 @@ testthat::describe("Backticked symbol", {
   testthat::it("starting with underscore is detected in code dependency", {
     td <- teal_data() |>
       within({
-        `_add_column_` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs) # nolint: object_name.
-        iris_ds <- `_add_column_`(iris, dplyr::tibble(new_col = "new column"))
+        `_add_column_` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
+        iris_ds <- `_add_column_`(iris, data.frame(new_col = "new column"))
       })
 
     testthat::expect_identical(
       get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
-        "`_add_column_` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "iris_ds <- `_add_column_`(iris, dplyr::tibble(new_col = \"new column\"))"
+        "`_add_column_` <- function(lhs, rhs) cbind(lhs, rhs)",
+        "iris_ds <- `_add_column_`(iris, data.frame(new_col = \"new column\"))"
       )
     )
   })
@@ -717,16 +717,16 @@ testthat::describe("Backticked symbol", {
   testthat::it("with space character is detected in code dependency", {
     td <- teal_data() |>
       within({
-        `add column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs) # nolint: object_name.
-        iris_ds <- `add column`(iris, dplyr::tibble(new_col = "new column"))
+        `add column` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
+        iris_ds <- `add column`(iris, data.frame(new_col = "new column"))
       })
 
     testthat::expect_identical(
       get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
-        "`add column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "iris_ds <- `add column`(iris, dplyr::tibble(new_col = \"new column\"))"
+        "`add column` <- function(lhs, rhs) cbind(lhs, rhs)",
+        "iris_ds <- `add column`(iris, data.frame(new_col = \"new column\"))"
       )
     )
   })
@@ -734,16 +734,16 @@ testthat::describe("Backticked symbol", {
   testthat::it("without special characters is cleaned and detecteed in code dependency", {
     td <- teal_data() |>
       within({
-        `add_column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
-        iris_ds <- `add_column`(iris, dplyr::tibble(new_col = "new column"))
+        `add_column` <- function(lhs, rhs) cbind(lhs, rhs)
+        iris_ds <- `add_column`(iris, data.frame(new_col = "new column"))
       })
 
     testthat::expect_identical(
       get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
-        "add_column <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "iris_ds <- add_column(iris, dplyr::tibble(new_col = \"new column\"))"
+        "add_column <- function(lhs, rhs) cbind(lhs, rhs)",
+        "iris_ds <- add_column(iris, data.frame(new_col = \"new column\"))"
       )
     )
   })
@@ -751,8 +751,8 @@ testthat::describe("Backticked symbol", {
   testthat::it("with non-native pipe used as function is detected code dependency", {
     td <- teal_data() |>
       within({
-        `%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
-        iris_ds <- `%add_column%`(iris, dplyr::tibble(new_col = "new column"))
+        `%add_column%` <- function(lhs, rhs) cbind(lhs, rhs)
+        iris_ds <- `%add_column%`(iris, data.frame(new_col = "new column"))
       })
 
     # Note that the original code is changed to use the non-native pipe operator
@@ -761,8 +761,8 @@ testthat::describe("Backticked symbol", {
       get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
-        "`%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "iris_ds <- iris %add_column% dplyr::tibble(new_col = \"new column\")"
+        "`%add_column%` <- function(lhs, rhs) cbind(lhs, rhs)",
+        "iris_ds <- iris %add_column% data.frame(new_col = \"new column\")"
       )
     )
   })
@@ -770,8 +770,8 @@ testthat::describe("Backticked symbol", {
   testthat::it("with non-native pipe is detected code dependency", {
     td <- teal_data() |>
       within({
-        `%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
-        iris_ds <- iris %add_column% dplyr::tibble(new_col = "new column")
+        `%add_column%` <- function(lhs, rhs) cbind(lhs, rhs)
+        iris_ds <- iris %add_column% data.frame(new_col = "new column")
       })
 
     # Note that the original code is changed to use the non-native pipe operator
@@ -780,8 +780,8 @@ testthat::describe("Backticked symbol", {
       get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
-        "`%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "iris_ds <- iris %add_column% dplyr::tibble(new_col = \"new column\")"
+        "`%add_column%` <- function(lhs, rhs) cbind(lhs, rhs)",
+        "iris_ds <- iris %add_column% data.frame(new_col = \"new column\")"
       )
     )
   })

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -697,6 +697,32 @@ testthat::test_that("data() call is returned when data name is provided as a cha
 })
 
 testthat::describe("Backticked symbol", {
+  testthat::it("code can be retrieved with get_code", {
+    td <- teal_data() |>
+      within({
+        `%cbind%` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
+        iris_ds <- iris %cbind% data.frame(new_col = "new column")
+      })
+
+    testthat::expect_identical(
+      get_code(td, datanames = "%cbind%"),
+      "`%cbind%` <- function(lhs, rhs) cbind(lhs, rhs)"
+    )
+  })
+
+  testthat::it("code can be retrieved with get_code", {
+    td <- teal_data() |>
+      within({
+        `%cbind%` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
+        iris_ds <- iris %cbind% data.frame(new_col = "new column")
+      })
+
+    testthat::expect_identical(
+      get_code(td, datanames = "`%cbind%`"),
+      "`%cbind%` <- function(lhs, rhs) cbind(lhs, rhs)"
+    )
+  })
+
   testthat::it("starting with underscore is detected in code dependency", {
     td <- teal_data() |>
       within({

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -700,16 +700,16 @@ testthat::describe("Backticked symbol", {
   testthat::it("starting with underscore is detected in code dependency", {
     td <- teal_data() |>
       within({
-        `_add_column_` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
-        IRIS <- `_add_column_`(iris, dplyr::tibble(new_col = "new column"))
+        `_add_column_` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs) # nolint: object_name.
+        iris_ds <- `_add_column_`(iris, dplyr::tibble(new_col = "new column"))
       })
 
     testthat::expect_identical(
-      get_code(td, datanames = "IRIS"),
+      get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
         "`_add_column_` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "IRIS <- `_add_column_`(iris, dplyr::tibble(new_col = \"new column\"))"
+        "iris_ds <- `_add_column_`(iris, dplyr::tibble(new_col = \"new column\"))"
       )
     )
   })
@@ -717,16 +717,16 @@ testthat::describe("Backticked symbol", {
   testthat::it("with space character is detected in code dependency", {
     td <- teal_data() |>
       within({
-        `add column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
-        IRIS <- `add column`(iris, dplyr::tibble(new_col = "new column"))
+        `add column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs) # nolint: object_name.
+        iris_ds <- `add column`(iris, dplyr::tibble(new_col = "new column"))
       })
 
     testthat::expect_identical(
-      get_code(td, datanames = "IRIS"),
+      get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
         "`add column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "IRIS <- `add column`(iris, dplyr::tibble(new_col = \"new column\"))"
+        "iris_ds <- `add column`(iris, dplyr::tibble(new_col = \"new column\"))"
       )
     )
   })
@@ -735,15 +735,15 @@ testthat::describe("Backticked symbol", {
     td <- teal_data() |>
       within({
         `add_column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
-        IRIS <- `add_column`(iris, dplyr::tibble(new_col = "new column"))
+        iris_ds <- `add_column`(iris, dplyr::tibble(new_col = "new column"))
       })
 
     testthat::expect_identical(
-      get_code(td, datanames = "IRIS"),
+      get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
         "add_column <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "IRIS <- add_column(iris, dplyr::tibble(new_col = \"new column\"))"
+        "iris_ds <- add_column(iris, dplyr::tibble(new_col = \"new column\"))"
       )
     )
   })
@@ -752,17 +752,17 @@ testthat::describe("Backticked symbol", {
     td <- teal_data() |>
       within({
         `%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
-        IRIS <- `%add_column%`(iris, dplyr::tibble(new_col = "new column"))
+        iris_ds <- `%add_column%`(iris, dplyr::tibble(new_col = "new column"))
       })
 
     # Note that the original code is changed to use the non-native pipe operator
     # correctly.
     testthat::expect_identical(
-      get_code(td, datanames = "IRIS"),
+      get_code(td, datanames = "iris_ds"),
       paste(
         sep = "\n",
         "`%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
-        "IRIS <- iris %add_column% dplyr::tibble(new_col = \"new column\")"
+        "iris_ds <- iris %add_column% dplyr::tibble(new_col = \"new column\")"
       )
     )
   })

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -748,11 +748,30 @@ testthat::describe("Backticked symbol", {
     )
   })
 
-  testthat::it("with non-native pipe is detected code dependency", {
+  testthat::it("with non-native pipe used as function is detected code dependency", {
     td <- teal_data() |>
       within({
         `%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
         iris_ds <- `%add_column%`(iris, dplyr::tibble(new_col = "new column"))
+      })
+
+    # Note that the original code is changed to use the non-native pipe operator
+    # correctly.
+    testthat::expect_identical(
+      get_code(td, datanames = "iris_ds"),
+      paste(
+        sep = "\n",
+        "`%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
+        "iris_ds <- iris %add_column% dplyr::tibble(new_col = \"new column\")"
+      )
+    )
+  })
+
+  testthat::it("with non-native pipe is detected code dependency", {
+    td <- teal_data() |>
+      within({
+        `%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
+        iris_ds <- iris %add_column% dplyr::tibble(new_col = "new column")
       })
 
     # Note that the original code is changed to use the non-native pipe operator

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -696,8 +696,8 @@ testthat::test_that("data() call is returned when data name is provided as a cha
   )
 })
 
-testthat::describe("Backticked special symbols", {
-  testthat::it("starting with underscore code dependency is being detected", {
+testthat::describe("Backticked symbol", {
+  testthat::it("starting with underscore is detected in code dependency", {
     td <- teal_data() |>
       within({
         `_add_column_` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
@@ -714,7 +714,7 @@ testthat::describe("Backticked special symbols", {
     )
   })
 
-  testthat::it("with spaces code dependency is being detected", {
+  testthat::it("with space character is detected in code dependency", {
     td <- teal_data() |>
       within({
         `add column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
@@ -731,7 +731,24 @@ testthat::describe("Backticked special symbols", {
     )
   })
 
-  testthat::it("with non-native pipe code dependency is being detected", {
+  testthat::it("without special characters is cleaned and detecteed in code dependency", {
+    td <- teal_data() |>
+      within({
+        `add_column` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
+        IRIS <- `add_column`(iris, dplyr::tibble(new_col = "new column"))
+      })
+
+    testthat::expect_identical(
+      get_code(td, datanames = "IRIS"),
+      paste(
+        sep = "\n",
+        "add_column <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)",
+        "IRIS <- add_column(iris, dplyr::tibble(new_col = \"new column\"))"
+      )
+    )
+  })
+
+  testthat::it("with non-native pipe is detected code dependency", {
     td <- teal_data() |>
       within({
         `%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -731,7 +731,7 @@ testthat::describe("Backticked symbol", {
     )
   })
 
-  testthat::it("without special characters is cleaned and detecteed in code dependency", {
+  testthat::it("without special characters is cleaned and detected in code dependency", {
     td <- teal_data() |>
       within({
         `add_column` <- function(lhs, rhs) cbind(lhs, rhs)

--- a/tests/testthat/test-get_code.R
+++ b/tests/testthat/test-get_code.R
@@ -698,11 +698,13 @@ testthat::test_that("data() call is returned when data name is provided as a cha
 
 testthat::describe("Backticked symbol", {
   testthat::it("code can be retrieved with get_code", {
-    td <- teal_data() |>
-      within({
+    td <- within(
+      teal_data(),
+      {
         `%cbind%` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
         iris_ds <- iris %cbind% data.frame(new_col = "new column")
-      })
+      }
+    )
 
     testthat::expect_identical(
       get_code(td, datanames = "%cbind%"),
@@ -711,11 +713,13 @@ testthat::describe("Backticked symbol", {
   })
 
   testthat::it("code can be retrieved with get_code", {
-    td <- teal_data() |>
-      within({
+    td <- within(
+      teal_data(),
+      {
         `%cbind%` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
         iris_ds <- iris %cbind% data.frame(new_col = "new column")
-      })
+      }
+    )
 
     testthat::expect_identical(
       get_code(td, datanames = "`%cbind%`"),
@@ -724,11 +728,13 @@ testthat::describe("Backticked symbol", {
   })
 
   testthat::it("starting with underscore is detected in code dependency", {
-    td <- teal_data() |>
-      within({
+    td <- within(
+      teal_data(),
+      {
         `_add_column_` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
         iris_ds <- `_add_column_`(iris, data.frame(new_col = "new column"))
-      })
+      }
+    )
 
     testthat::expect_identical(
       get_code(td, datanames = "iris_ds"),
@@ -741,11 +747,13 @@ testthat::describe("Backticked symbol", {
   })
 
   testthat::it("with space character is detected in code dependency", {
-    td <- teal_data() |>
-      within({
+    td <- within(
+      teal_data(),
+      {
         `add column` <- function(lhs, rhs) cbind(lhs, rhs) # nolint: object_name.
         iris_ds <- `add column`(iris, data.frame(new_col = "new column"))
-      })
+      }
+    )
 
     testthat::expect_identical(
       get_code(td, datanames = "iris_ds"),
@@ -758,11 +766,13 @@ testthat::describe("Backticked symbol", {
   })
 
   testthat::it("without special characters is cleaned and detected in code dependency", {
-    td <- teal_data() |>
-      within({
+    td <- within(
+      teal_data(),
+      {
         `add_column` <- function(lhs, rhs) cbind(lhs, rhs)
         iris_ds <- `add_column`(iris, data.frame(new_col = "new column"))
-      })
+      }
+    )
 
     testthat::expect_identical(
       get_code(td, datanames = "iris_ds"),
@@ -775,11 +785,13 @@ testthat::describe("Backticked symbol", {
   })
 
   testthat::it("with non-native pipe used as function is detected code dependency", {
-    td <- teal_data() |>
-      within({
+    td <- within(
+      teal_data(),
+      {
         `%add_column%` <- function(lhs, rhs) cbind(lhs, rhs)
         iris_ds <- `%add_column%`(iris, data.frame(new_col = "new column"))
-      })
+      }
+    )
 
     # Note that the original code is changed to use the non-native pipe operator
     # correctly.
@@ -794,11 +806,13 @@ testthat::describe("Backticked symbol", {
   })
 
   testthat::it("with non-native pipe is detected code dependency", {
-    td <- teal_data() |>
-      within({
+    td <- within(
+      teal_data(),
+      {
         `%add_column%` <- function(lhs, rhs) cbind(lhs, rhs)
         iris_ds <- iris %add_column% data.frame(new_col = "new column")
-      })
+      }
+    )
 
     # Note that the original code is changed to use the non-native pipe operator
     # correctly.


### PR DESCRIPTION
WIP

# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes https://github.com/insightsengineering/teal/issues/1366

Related:

- https://github.com/insightsengineering/teal/pull/1382
- https://github.com/insightsengineering/teal.slice/pull/622
- https://github.com/insightsengineering/teal.data/pull/340

### Changes description

- [x] Adds support for non-standard names in code dependency
- [x] Support backtick symbols in code dependency

<details>

<summary>Reproducible code for backtick support in code parser</summary>

`%add_column%` definition is not detected

```r
pkgload::load_all("teal.data")
#> ℹ Loading teal.data
#> Loading required package: teal.code
td <- teal_data() |> 
  within({
    IRIS <- iris
    IRIS2 <- iris
    MTCARS <- mtcars
    `%add_column%` <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs) # @
    add_column <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
    IRIS <- IRIS %add_column% dplyr::tibble(yada = IRIS2$Species)
    IRIS <- add_column(IRIS, dplyr::tibble(yada2 = IRIS2$Species))
  })

td |> get_code(datanames = "IRIS") |> cat()
#> IRIS <- iris
#> IRIS2 <- iris
#> add_column <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
#> IRIS <- IRIS %add_column% dplyr::tibble(yada = IRIS2$Species)
#> IRIS <- add_column(IRIS, dplyr::tibble(yada2 = IRIS2$Species))

td2 <- td |> 
  within({
    IRIS <- `%add_column%`(IRIS, dplyr::tibble(yada2 = IRIS2$Species))
  })

td2 |> get_code(datanames = "IRIS") |> cat()
#> IRIS <- iris
#> IRIS2 <- iris
#> add_column <- function(lhs, rhs) dplyr::bind_cols(lhs, rhs)
#> IRIS <- IRIS %add_column% dplyr::tibble(yada = IRIS2$Species)
#> IRIS <- add_column(IRIS, dplyr::tibble(yada2 = IRIS2$Species))
#> IRIS <- IRIS %add_column% dplyr::tibble(yada2 = IRIS2$Species)
```

<sup>Created on 2024-10-15 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

</details>
