### PR TITLE
vbump teal.code

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ URL: https://insightsengineering.github.io/teal.data/,
 BugReports: https://github.com/insightsengineering/teal.data/issues
 Depends:
     R (>= 4.0),
-    teal.code (>= 0.5.0)
+    teal.code (>= 0.5.0.9011)
 Imports:
     checkmate (>= 2.1.0),
     lifecycle (>= 0.2.0),


### PR DESCRIPTION
Require higher `teal.code` version after we transitioned `teal.data::get_code` into `teal.code::get_code` and we are using `teal.code::get_code` inside `teal.data` package.