### PR TITLE
Update `teal.code` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ URL: https://insightsengineering.github.io/teal.data/,
 BugReports: https://github.com/insightsengineering/teal.data/issues
 Depends:
     R (>= 4.0),
-    teal.code (>= 0.5.0.9012)
+    teal.code (>= 0.5.0.9015)
 Imports:
     checkmate (>= 2.1.0),
     lifecycle (>= 0.2.0),


### PR DESCRIPTION
`[.qenv` was introduced in `teal.code` `0.5.9014` so we need to depend on this or higher to get `[.teal_data`