### PR TITLE
Fix documentation note about links on r-devel

### DIFF
--- a/R/teal_data-class.R
+++ b/R/teal_data-class.R
@@ -16,10 +16,10 @@ setOldClass("join_keys")
 #'
 #' @slot .xData (`environment`) environment containing data sets and possibly
 #'  auxiliary variables.
-#'  Access variables with [get()], [`$`], [get_var()] or [`[[`].
+#'  Access variables with [get()], [`$`], [teal.code::get_var()] or [`[[`].
 #'  No setter provided. Evaluate code to add variables into `@.xData`.
 #' @slot code (`list` of `character`) representing code necessary to reproduce the contents of `qenv`.
-#'  Access with [get_code()].
+#'  Access with [teal.code::get_code()].
 #'  No setter provided. Evaluate code to append code to the slot.
 #' @slot join_keys (`join_keys`) object specifying joining keys for data sets in
 #' `@.xData`.

--- a/man/teal_data-class.Rd
+++ b/man/teal_data-class.Rd
@@ -20,11 +20,11 @@ If errors are raised, a \code{qenv.error} object is returned.
 \describe{
 \item{\code{.xData}}{(\code{environment}) environment containing data sets and possibly
 auxiliary variables.
-Access variables with \code{\link[=get]{get()}}, \code{\link{$}}, \code{\link[=get_var]{get_var()}} or [\code{[[}].
+Access variables with \code{\link[=get]{get()}}, \code{\link{$}}, \code{\link[teal.code:get_var]{teal.code::get_var()}} or [\code{[[}].
 No setter provided. Evaluate code to add variables into \verb{@.xData}.}
 
 \item{\code{code}}{(\code{list} of \code{character}) representing code necessary to reproduce the contents of \code{qenv}.
-Access with \code{\link[=get_code]{get_code()}}.
+Access with \code{\link[teal.code:qenv]{teal.code::get_code()}}.
 No setter provided. Evaluate code to append code to the slot.}
 
 \item{\code{join_keys}}{(\code{join_keys}) object specifying joining keys for data sets in


### PR DESCRIPTION
# Pull Request

Fixes #335 

The links are correctly resolved to the package and `R CMD check` doesn't complain (with 2024-12-07 r87428 ucrt)

See https://github.com/insightsengineering/teal/issues/1420#issuecomment-2535506586 for a longer explanation.
