### PR TITLE
update testthat version

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -36,6 +36,7 @@ jobs:
       GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
     with:
       strategy: ${{ matrix.test-strategy }}
+      extra-deps: waldo (>= 0.5.3)
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
   branch-cleanup:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -36,7 +36,6 @@ jobs:
       GCHAT_WEBHOOK: ${{ secrets.GCHAT_WEBHOOK }}
     with:
       strategy: ${{ matrix.test-strategy }}
-      extra-deps: waldo (>= 0.5.3)
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
   branch-cleanup:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     rmarkdown (>= 2.23),
-    testthat (>= 3.1.8),
+    testthat (>= 3.2.2),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     rmarkdown (>= 2.23),
-    testthat (>= 3.1.8),
+    testthat (>= 3.2.0),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     rmarkdown (>= 2.23),
-    testthat (>= 3.1.5),
+    testthat (>= 3.1.8),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
 Suggests:
     knitr (>= 1.42),
     rmarkdown (>= 2.23),
-    testthat (>= 3.2.0),
+    testthat (>= 3.1.8),
     withr (>= 2.0.0)
 VignetteBuilder:
     knitr,

--- a/tests/testthat/test-cdisc_join_keys.R
+++ b/tests/testthat/test-cdisc_join_keys.R
@@ -1,5 +1,5 @@
 testthat::test_that("default_cdisc_join_keys is assigned in package environment", {
-  testthat::expect_true(exists("default_cdisc_join_keys"))
+  testthat::expect_true(exists("default_cdisc_join_keys", where = asNamespace("teal.data")))
   testthat::expect_gt(length(default_cdisc_join_keys), 0)
 })
 


### PR DESCRIPTION
We need to bump up `testthat` version because we're using `testthat::it` function in unit tests.

This function was introduced in `3.1.8`:
https://github.com/r-lib/testthat/blob/v3.1.8/R/describe.R#L89

This update will fix the `Dependency Test - min isolated`:
https://github.com/insightsengineering/teal.data/actions/runs/12532231366/job/34950746107#step:9:774
