### PR TITLE
Fix typo on documentation

### DIFF
--- a/R/join_keys.R
+++ b/R/join_keys.R
@@ -26,12 +26,11 @@
 #' - either `teal_data` or `join_keys` object to extract `join_keys`
 #' - or any number of `join_key_set` objects to create `join_keys`
 #' - or nothing to create an empty `join_keys`
-#' @param value For `x[i, j, directed = TRUE)] <- value` (named/unnamed `character`)
+#' @param value For `x[i, j, directed = TRUE] <- value` (named/unnamed `character`)
 #' Column mapping between datasets.
 #'
 #' For `join_keys(x) <- value`: (`join_key_set` or list of `join_key_set`) relationship
 #' pairs to add to `join_keys` list.
-#'
 #'
 #' @return `join_keys` object.
 #'

--- a/man/join_keys.Rd
+++ b/man/join_keys.Rd
@@ -66,13 +66,11 @@ a parent-child relationship between the datasets.
 \item \code{FALSE} when the relationship is undirected.
 }}
 
-\item{value}{For \verb{x[i, j, directed = TRUE)] <- value} (named/unnamed \code{character})
+\item{value}{For \code{x[i, j, directed = TRUE] <- value} (named/unnamed \code{character})
 Column mapping between datasets.
 
 For \code{join_keys(x) <- value}: (\code{join_key_set} or list of \code{join_key_set}) relationship
-pairs to add to \code{join_keys} list.
-
-[i, j, directed = TRUE)]: R:i,\%20j,\%20directed\%20=\%20TRUE)}
+pairs to add to \code{join_keys} list.}
 }
 \value{
 \code{join_keys} object.


### PR DESCRIPTION
# Pull Request

There is a weird [extra line on `join_keys` documentation for value argument](https://insightsengineering.github.io/teal.data/latest-tag/reference/join_keys.html#arg-value).

> [i, j, directed = TRUE)]: R:i,\%20j,\%20directed\%20=\%20TRUE)}

A typo on the R code is the cause