### PR TITLE
fix tests after change in `testthat::expect_equal`

### DIFF
--- a/tests/testthat/test-join_keys-c.R
+++ b/tests/testthat/test-join_keys-c.R
@@ -178,9 +178,8 @@ testthat::test_that("c.join_keys merges existing parents are overwritten", {
     join_key("d3", "d4", "cd", directed = FALSE),
     join_key("d2", "d3", "cb", directed = FALSE)
   )
-  parents(expected) <- list(d2 = "d1", d3 = "d2", d4 = "d3")
-
-  testthat::expect_equal(c(jk1, jk2), expected)
+  parents(expected) <- list(d2 = "d1", d4 = "d3", d3 = "d2")
+  testthat::expect_identical(c(jk1, jk2), expected)
 })
 
 testthat::test_that("c.join_keys throws error when merge produces acyclical graph", {

--- a/tests/testthat/test-join_keys-extract.R
+++ b/tests/testthat/test-join_keys-extract.R
@@ -60,12 +60,12 @@ testthat::test_that("join_keys[i] returns join_keys object for given dataset inc
   )
 
   expected <- join_keys(
-    join_key("d1", "d1", "a"),
     join_key("d2", "d2", "b"),
+    join_key("d1", "d1", "a"),
     join_key("d1", "d2", "ab")
   )
 
-  testthat::expect_equal(my_keys["d2"], expected)
+  testthat::expect_identical(my_keys["d2"], expected)
 })
 
 testthat::test_that("join_keys[i] returns join_keys object for given dataset and doesn't include its children", {
@@ -78,12 +78,12 @@ testthat::test_that("join_keys[i] returns join_keys object for given dataset and
   )
 
   expected <- join_keys(
-    join_key("d1", "d1", "a"),
     join_key("d2", "d2", "b"),
+    join_key("d1", "d1", "a"),
     join_key("d1", "d2", "ab")
   )
 
-  testthat::expect_equal(my_keys["d2"], expected)
+  testthat::expect_identical(my_keys["d2"], expected)
 })
 
 testthat::test_that("join_keys[i] returns empty join_keys for inexisting dataset", {
@@ -268,11 +268,15 @@ testthat::test_that("join_keys[i,j]<- removes keys with NULL", {
   )
   my_keys["d2", "d1"] <- NULL
 
-  testthat::expect_equal(
+  testthat::expect_identical(
     my_keys,
-    join_keys(
-      join_key("d1", "d1", "A"),
-      join_key("d2", "d2", "B")
+    structure(
+      list(
+        d1 = list(d1 = c(A = "A")),
+        d2 = list(d2 = c(B = "B"))
+      ),
+      parents = setNames(list(), character(0)), # named list
+      class = c("join_keys", "list")
     )
   )
 })
@@ -330,17 +334,18 @@ testthat::test_that("[[<-.join_keys adds symmetrical change without parents to t
   jk <- join_keys()
   jk[["d1"]][["d2"]] <- c("A" = "B", "C" = "C")
 
-  testthat::expect_equal(
+  testthat::expect_identical(
     jk,
     structure(
       list(
         d1 = list(
-          d2 = c(c("A" = "B", "C" = "C"))
+          d2 = c("A" = "B", "C" = "C")
         ),
         d2 = list(
           d1 = c("B" = "A", "C" = "C")
         )
       ),
+      parents = list(),
       class = c("join_keys", "list")
     )
   )

--- a/tests/testthat/test-join_keys.R
+++ b/tests/testthat/test-join_keys.R
@@ -64,7 +64,7 @@ testthat::test_that("join_keys is a collection of join_key, ie named list with n
       "parents" = list()
     )
   )
-  # Relaxed comparison (not ordered and without need of empty attributes)
+
   testthat::expect_identical(
     jk,
     structure(

--- a/tests/testthat/test-join_keys.R
+++ b/tests/testthat/test-join_keys.R
@@ -64,15 +64,15 @@ testthat::test_that("join_keys is a collection of join_key, ie named list with n
       "parents" = list()
     )
   )
-
   # Relaxed comparison (not ordered and without need of empty attributes)
-  testthat::expect_equal(
+  testthat::expect_identical(
     jk,
     structure(
       list(
-        d2 = list(d2 = c(test = "test")),
-        d1 = list(d1 = c(test = "test"))
+        d1 = list(d1 = c(test = "test")),
+        d2 = list(d2 = c(test = "test"))
       ),
+      parents = list(),
       class = c("join_keys", "list")
     )
   )
@@ -100,21 +100,33 @@ testthat::test_that("join_keys.join_keys returns itself", {
 
 testthat::test_that("join_keys constructor adds symmetric keys on given (unnamed) foreign key", {
   my_keys <- join_keys(join_key("d1", "d2", "a"))
-  expected_keys <- join_keys(join_key("d2", "d1", "a", directed = FALSE))
-  parents(expected_keys) <- list(d2 = "d1")
-
-  testthat::expect_equal(my_keys, expected_keys)
+  testthat::expect_identical(
+    my_keys,
+    structure(
+      list(
+        d1 = list(d2 = c(a = "a")),
+        d2 = list(d1 = c(a = "a"))
+      ),
+      parents = list(d2 = "d1"),
+      class = c("join_keys", "list")
+    )
+  )
 })
 
 testthat::test_that("join_keys constructor adds symmetric keys on given (named) foreign key", {
-  expected_keys <- join_keys(join_key("d2", "d1", c(b = "a"), directed = FALSE))
-  parents(expected_keys) <- list(d2 = "d1")
+  my_keys <- join_keys(join_key("d2", "d1", c(b = "a"), directed = FALSE))
+  parents(my_keys) <- list(d2 = "d1")
 
   testthat::expect_equal(
-    join_keys(
-      join_key("d1", "d2", c(a = "b"))
-    ),
-    expected_keys
+    my_keys,
+    structure(
+      list(
+        d2 = list(d1 = c(b = "a")),
+        d1 = list(d2 = c(a = "b"))
+      ),
+      parents = list(d2 = "d1"),
+      class = c("join_keys", "list")
+    )
   )
 })
 


### PR DESCRIPTION
Looks like `testthat::expect_equal` have changed. It doesn't recognize list sorted in a different way as equal. It also notices the difference between `named list(0)` and `list(0)`

Above is just the assumption, the fact is that some tests doesn't work anymore.