### PR TITLE
change message in show method for `teal_data`

### DIFF
--- a/R/teal_data-show.R
+++ b/R/teal_data-show.R
@@ -12,9 +12,9 @@
 #' @export
 setMethod("show", signature = "teal_data", function(object) {
   if (object@verified) {
-    cat("\u2705\ufe0e", "verified teal_data object\n")
+    cat("\u2705\ufe0e", "code verified\n")
   } else {
-    cat("\u2716", "unverified teal_data object\n")
+    cat("\u2716", "code unverified\n")
   }
   methods::callNextMethod(object)
   invisible(object)


### PR DESCRIPTION
I've suggested "code verified/unverified" because:
1. It's concise and clear
2. It focuses on what's actually being verified (the code that created the data)
3. It removes the redundant "teal_data object" since this is already known from the context