### PR TITLE
Update lifecycle badges

### DIFF
--- a/R/cdisc_data.R
+++ b/R/cdisc_data.R
@@ -1,7 +1,6 @@
 #' Data input for `teal` app
 #'
 #' @description
-#' `r lifecycle::badge("stable")`
 #'
 #' Function is a wrapper around [teal_data()] and guesses `join_keys`
 #' for given datasets whose names match ADAM datasets names.

--- a/R/join_key.R
+++ b/R/join_key.R
@@ -1,7 +1,6 @@
 #' Create a relationship between a pair of datasets
 #'
 #' @description
-#' `r lifecycle::badge("stable")`
 #'
 #' Create a relationship between two datasets, `dataset_1` and `dataset_2`.
 #' By default, this function establishes a directed relationship with `dataset_1` as the parent.

--- a/R/teal_data-constructor.R
+++ b/R/teal_data-constructor.R
@@ -1,7 +1,6 @@
 #' Comprehensive data integration function for `teal` applications
 #'
 #' @description
-#' `r lifecycle::badge("stable")`
 #'
 #' Initializes a data for `teal` application.
 #'

--- a/man/cdisc_data.Rd
+++ b/man/cdisc_data.Rd
@@ -27,8 +27,6 @@ Use \code{\link[=verify]{verify()}} to verify code reproducibility.}
 A \code{teal_data} object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-
 Function is a wrapper around \code{\link[=teal_data]{teal_data()}} and guesses \code{join_keys}
 for given datasets whose names match ADAM datasets names.
 }

--- a/man/join_key.Rd
+++ b/man/join_key.Rd
@@ -30,8 +30,6 @@ a parent-child relationship between the datasets.
 object of class \code{join_key_set} to be passed into \code{join_keys} function.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-
 Create a relationship between two datasets, \code{dataset_1} and \code{dataset_2}.
 By default, this function establishes a directed relationship with \code{dataset_1} as the parent.
 If \code{dataset_2} is not specified, the function creates a primary key for \code{dataset_1}.

--- a/man/teal_data-class.Rd
+++ b/man/teal_data-class.Rd
@@ -36,4 +36,19 @@ proven to yield contents of \verb{@.xData}.
 Used internally. See \code{\link[=verify]{verify()}} for more details.}
 }}
 
+\section{Code}{
+
+
+
+Each code element is a character representing one call. Each element is named with the random
+identifier to make sure uniqueness when joining. Each element has possible attributes:
+\itemize{
+\item \code{warnings} (\code{character}) the warnings output when evaluating the code element.
+\item \code{messages} (\code{character}) the messages output when evaluating the code element.
+\item \code{dependency} (\code{character}) names of objects that appear in this call and gets affected by this call,
+separated by \verb{<-} (objects on LHS of \verb{<-} are affected by this line, and objects on RHS are affecting this line).
+}
+
+}
+
 \keyword{internal}

--- a/man/teal_data-class.Rd
+++ b/man/teal_data-class.Rd
@@ -36,19 +36,4 @@ proven to yield contents of \verb{@.xData}.
 Used internally. See \code{\link[=verify]{verify()}} for more details.}
 }}
 
-\section{Code}{
-
-
-
-Each code element is a character representing one call. Each element is named with the random
-identifier to make sure uniqueness when joining. Each element has possible attributes:
-\itemize{
-\item \code{warnings} (\code{character}) the warnings output when evaluating the code element.
-\item \code{messages} (\code{character}) the messages output when evaluating the code element.
-\item \code{dependency} (\code{character}) names of objects that appear in this call and gets affected by this call,
-separated by \verb{<-} (objects on LHS of \verb{<-} are affected by this line, and objects on RHS are affecting this line).
-}
-
-}
-
 \keyword{internal}

--- a/man/teal_data.Rd
+++ b/man/teal_data.Rd
@@ -29,8 +29,6 @@ Use \code{\link[=verify]{verify()}} to verify code reproducibility.}
 A \code{teal_data} object.
 }
 \description{
-\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-
 Initializes a data for \code{teal} application.
 }
 \details{


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/649

Removed stable badges.
Deprecated functions were introduced in 0.7.0, so its not yet 2 minor releases. In the next release we will change from soft to hard deprecation.