### PR TITLE
[skip vbump] upversion v0.8.0

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -38,6 +38,8 @@ jobs:
       strategy: ${{ matrix.test-strategy }}
       additional-env-vars: |
         PKG_SYSREQS_DRY_RUN=true
+      extra-deps: |
+        sass (>= 0.4.9)
   branch-cleanup:
     if: >
       github.event_name == 'schedule' || (

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: teal.data
 Title: Data Model for 'teal' Applications
-Version: 0.7.0.9006
-Date: 2025-08-11
+Version: 0.8.0
+Date: 2025-08-18
 Authors@R: c(
     person("Dawid", "Kaledkowski", , "dawid.kaledkowski@roche.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0001-9533-457X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Depends:
     R (>= 4.0),
     teal.code (>= 0.7.0)
 Imports:
-    checkmate (>= 2.1.0),
+    checkmate (>= 2.3.0),
     lifecycle (>= 0.2.0),
     methods,
     rlang (>= 1.1.0),
@@ -42,7 +42,7 @@ Suggests:
     random.cdisc.data (>= 0.2.1),
     rmarkdown (>= 2.23),
     testthat (>= 3.2.2),
-    withr (>= 2.0.0)
+    withr (>= 3.0.0)
 VignetteBuilder:
     knitr,
     rmarkdown

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ URL: https://insightsengineering.github.io/teal.data/,
 BugReports: https://github.com/insightsengineering/teal.data/issues
 Depends:
     R (>= 4.0),
-    teal.code (>= 0.6.1.9002)
+    teal.code (>= 0.7.0)
 Imports:
     checkmate (>= 2.1.0),
     lifecycle (>= 0.2.0),
@@ -48,8 +48,6 @@ VignetteBuilder:
     rmarkdown
 RdMacros:
     lifecycle
-Remotes:
-    insightsengineering/teal.code@main
 Config/Needs/verdepcheck: insightsengineering/teal.code, mllg/checkmate,
     r-lib/lifecycle, r-lib/rlang, yihui/knitr, rstudio/rmarkdown,
     insightsengineering/random.cdisc.data, r-lib/testthat, r-lib/withr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.data 0.7.0.9006
+# teal.data 0.8.0
 
 ### Breaking changes
 


### PR DESCRIPTION
Closes #379 

[teal.code 0.7.0](https://github.com/insightsengineering/teal.code/issues/269) needs to release to CRAN first.


* Update DESCRIPTION and NEWS
* Update teal code version