### PR TITLE
chore: bump teal.code dependency to 0.7.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,8 +48,6 @@ VignetteBuilder:
     rmarkdown
 RdMacros:
     lifecycle
-Remotes:
-    
 Config/Needs/verdepcheck: insightsengineering/teal.code, mllg/checkmate,
     r-lib/lifecycle, r-lib/rlang, yihui/knitr, rstudio/rmarkdown,
     insightsengineering/random.cdisc.data, r-lib/testthat, r-lib/withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ URL: https://insightsengineering.github.io/teal.data/,
 BugReports: https://github.com/insightsengineering/teal.data/issues
 Depends:
     R (>= 4.0),
-    teal.code (>= 0.6.1.9002)
+    teal.code (>= 0.7.0)
 Imports:
     checkmate (>= 2.1.0),
     lifecycle (>= 0.2.0),
@@ -49,7 +49,7 @@ VignetteBuilder:
 RdMacros:
     lifecycle
 Remotes:
-    insightsengineering/teal.code@main
+    
 Config/Needs/verdepcheck: insightsengineering/teal.code, mllg/checkmate,
     r-lib/lifecycle, r-lib/rlang, yihui/knitr, rstudio/rmarkdown,
     insightsengineering/random.cdisc.data, r-lib/testthat, r-lib/withr


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.code (>= 0.7.0) and removes it from Remotes.